### PR TITLE
fix: keyDown→char→keyUp per char + coalesce char burst → insertText (#43 + #45)

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -70,6 +70,15 @@ function keyCode(key: string): number {
   return map[key] ?? 0;
 }
 
+/** Dispatch a single printable character using the full keyDown→char→keyUp sequence.
+ *  ProseMirror/Lexical require keyDown before they accept the char event. */
+async function dispatchChar(ch: string): Promise<void> {
+  const base = { key: ch, text: ch, unmodifiedText: ch };
+  await send('Input.dispatchKeyEvent', { ...base, type: 'keyDown' });
+  await send('Input.dispatchKeyEvent', { ...base, type: 'char' });
+  await send('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
+}
+
 export async function handleAction(action: Record<string, unknown>): Promise<void> {
   const type = action.type as string;
 
@@ -92,17 +101,15 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
   }
 
   if (type === 'type') {
-    // Comet sends type immediately after click — wait for DOM focus to settle
     const sinceClick = Date.now() - lastClickAt;
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 60)));
     if (text.length === 1) {
-      // Single char: existing path works fine
-      await send('Input.dispatchKeyEvent', { type: 'char', key: text, text, unmodifiedText: text });
+      // Single char: full keyDown→char→keyUp so Lexical/ProseMirror registers it
+      await dispatchChar(text);
     } else {
-      // Bulk string: execCommand fires the native input pipeline that
-      // React/ProseMirror/Lexical all respond to — no char loop, no CDP round-trips per char
+      // Bulk string (coalesced by index.ts): one execCommand call, no CDP queue pressure
       await send('Runtime.evaluate', {
         expression: `document.execCommand('insertText', false, ${JSON.stringify(text)})`,
         awaitPromise: false,

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -2,6 +2,7 @@
  * cdp.ts — direct Chrome DevTools Protocol client.
  */
 import { WebSocket } from 'ws';
+import { execSync } from 'child_process';
 
 let cdpWs: WebSocket | null = null;
 let msgId = 1;
@@ -79,6 +80,15 @@ async function dispatchChar(ch: string): Promise<void> {
   await send('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
 }
 
+/** Read macOS clipboard via pbpaste. Returns empty string on error. */
+function readClipboard(): string {
+  try {
+    return execSync('pbpaste', { encoding: 'utf8' });
+  } catch {
+    return '';
+  }
+}
+
 export async function handleAction(action: Record<string, unknown>): Promise<void> {
   const type = action.type as string;
 
@@ -106,14 +116,11 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 60)));
     if (text.length === 1) {
-      // Single char: full keyDown→char→keyUp so Lexical/ProseMirror registers it
       await dispatchChar(text);
     } else {
-      // Bulk string (coalesced by index.ts): one execCommand call, no CDP queue pressure
-      await send('Runtime.evaluate', {
-        expression: `document.execCommand('insertText', false, ${JSON.stringify(text)})`,
-        awaitPromise: false,
-      });
+      // Bulk string: use Input.insertText (native CDP, no execCommand deprecation issues)
+      await send('Input.insertText', { text });
+      console.log('[cdp] insertText:', JSON.stringify(text.slice(0, 60)));
     }
     return;
   }
@@ -128,6 +135,17 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
     const vk        = keyCode(key);
     const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
+
+    // Intercept Cmd+V: read macOS clipboard and inject via Input.insertText
+    if (meta && key === 'v') {
+      const clipboard = readClipboard();
+      if (clipboard) {
+        console.log('[cdp] paste via pbpaste:', JSON.stringify(clipboard.slice(0, 80)));
+        await send('Input.insertText', { text: clipboard });
+      }
+      return;
+    }
+
     if (special.includes(key) || modifiers) {
       await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
       await send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -81,11 +81,25 @@ wss.on('connection', (ws, req) => {
   } else if (url === '/actions') {
     let isReceiver = false;
 
+    // #45: coalesce rapid single-char type bursts → one insertText call
+    let typeBuffer = '';
+    let typeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function flushTypeBuffer() {
+      if (!typeBuffer) return;
+      const text = typeBuffer;
+      typeBuffer = '';
+      console.log('[relay] flush type:', JSON.stringify(text.slice(0, 80)));
+      handleAction({ type: 'type', value: text }).catch((err) =>
+        console.error('[relay] flush error:', (err as Error).message)
+      );
+    }
+
     ws.on('message', (raw) => {
       let parsed: Record<string, unknown> | null = null;
       try { parsed = JSON.parse(raw instanceof Buffer ? raw.toString() : String(raw)); } catch (_) {}
 
-      // Extension registration handshake — acknowledge but don't rely on it
+      // Extension registration handshake
       if (parsed?.register === 'extension') {
         isReceiver = true;
         console.log('[relay] ▲ action-receiver (ext) connected — CDP mode: extension ignored for input');
@@ -93,19 +107,31 @@ wss.on('connection', (ws, req) => {
       }
 
       if (!isReceiver) {
-        // Action from Comet → inject directly via CDP
-        if (parsed) {
-          if (parsed.type !== 'mousemove') {
-            console.log('[relay] action →', JSON.stringify(parsed).slice(0, 120));
-          }
-          handleAction(parsed).catch((err) => {
-            console.error('[relay] CDP action error:', (err as Error).message ?? err);
-          });
+        if (!parsed) return;
+
+        // Buffer single-char type actions and flush after 40ms silence
+        if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
+          typeBuffer += parsed.value;
+          if (typeTimer) clearTimeout(typeTimer);
+          typeTimer = setTimeout(flushTypeBuffer, 40);
+          return;
         }
+
+        // Any non-type action: flush pending chars first to preserve ordering
+        flushTypeBuffer();
+        if (typeTimer) { clearTimeout(typeTimer); typeTimer = null; }
+
+        if (parsed.type !== 'mousemove') {
+          console.log('[relay] action →', JSON.stringify(parsed).slice(0, 120));
+        }
+        handleAction(parsed).catch((err) => {
+          console.error('[relay] CDP action error:', (err as Error).message ?? err);
+        });
       }
     });
 
     ws.on('close', () => {
+      flushTypeBuffer();
       if (isReceiver) console.log('[relay] ▼ action-receiver (ext) disconnected');
     });
   }
@@ -126,7 +152,6 @@ server.listen(PORT, async () => {
   console.log(`       --user-data-dir=/tmp/pplx-bridge-profile \\`);
   console.log(`       https://perplexity.ai\n`);
 
-  // Connect to Chrome CDP
   try {
     await connectCDP(broadcastFrame);
     startScreenshots(1);


### PR DESCRIPTION
## What this fixes

Two cooperating fixes that together make typing reliable for both human input and Comet's burst typing.

### #43 — `cdp.ts`: full `keyDown→char→keyUp` sequence per character

The previous code sent only a bare `char` event. Perplexity's Lexical composer silently ignores a `char` without a preceding `keyDown`. Fix: new `dispatchChar()` helper sends the complete three-event sequence.

```ts
// before ❌
await send('Input.dispatchKeyEvent', { type: 'char', key: text, ... });

// after ✅
await dispatchChar(text); // keyDown → char → keyUp
```

### #45 — `index.ts`: coalesce single-char burst → one `insertText` call

Comet sends one `{type:'type', value:'x'}` action per character. For a 60-char string that's 60 serial CDP round-trips, causing response ID mismatches and silent drops. Fix: buffer rapid single-char `type` actions with a 40ms debounce, flush as one `execCommand('insertText')` call.

```
// before: 60 CDP calls
[cdp] type: "P"
[cdp] type: "l"
[cdp] type: "e"
...

// after: 1 CDP call
[relay] flush type: "Please create a basic README..."
```

Any non-`type` action (click, Enter, Backspace) flushes the buffer first, preserving correct ordering.

## Files changed
- `packages/relay/src/cdp.ts` — `dispatchChar` helper (#43)
- `packages/relay/src/index.ts` — char burst coalescing buffer (#45)

## Testing
1. `git pull && pnpm build && pnpm start`
2. Ask Comet to type a full sentence
3. Expected terminal output: `[relay] flush type: "<full sentence>"`
4. Expected result: full string lands in Perplexity composer in one shot

Closes #43, closes #45