### PR TITLE
fix: bulk type lands in Perplexity Lexical composer (#43 #45 #46)

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -96,9 +96,25 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
-    // Input.insertText handles both single chars and full strings in one round-trip.
-    // Lexical registers it correctly via the native text insertion path.
-    await send('Input.insertText', { text });
+
+    // Focus the Lexical contenteditable and insert text in one JS call.
+    // execCommand('insertText') goes through the browser's native input pipeline
+    // (beforeinput -> input events) which React/Lexical/ProseMirror all respond to.
+    // This works for both single chars and full strings.
+    // We explicitly focus [data-lexical-editor] first; if not present, fall back to
+    // any focused/active contenteditable so execCommand has a valid target.
+    const result = await send('Runtime.evaluate', {
+      expression: `(function() {
+  var el = document.querySelector('[data-lexical-editor="true"]');
+  if (!el) el = document.activeElement;
+  if (el) { el.focus(); }
+  var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
+  return ok;
+})()`,
+      returnByValue: true,
+      awaitPromise: false,
+    }) as { result: { value: unknown } };
+    console.log('[cdp] execCommand result:', result?.result?.value);
     return;
   }
 

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -70,6 +70,18 @@ function keyCode(key: string): number {
   return map[key] ?? 0;
 }
 
+/**
+ * Dispatch a single printable character via the full keyDown → char → keyUp
+ * sequence that Lexical / ProseMirror / React require to register input.
+ * A bare `char` event without a preceding `keyDown` is silently ignored.
+ */
+async function dispatchChar(ch: string): Promise<void> {
+  const base = { key: ch, text: ch, unmodifiedText: ch };
+  await send('Input.dispatchKeyEvent', { ...base, type: 'keyDown' });
+  await send('Input.dispatchKeyEvent', { ...base, type: 'char' });
+  await send('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
+}
+
 export async function handleAction(action: Record<string, unknown>): Promise<void> {
   const type = action.type as string;
 
@@ -92,17 +104,17 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
   }
 
   if (type === 'type') {
-    // Comet sends type immediately after click — wait for DOM focus to settle
+    // Wait for DOM focus to settle after a click
     const sinceClick = Date.now() - lastClickAt;
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 60)));
     if (text.length === 1) {
-      // Single char: existing path works fine
-      await send('Input.dispatchKeyEvent', { type: 'char', key: text, text, unmodifiedText: text });
+      // Single char: full keyDown → char → keyUp so Lexical registers it
+      await dispatchChar(text);
     } else {
       // Bulk string: execCommand fires the native input pipeline that
-      // React/ProseMirror/Lexical all respond to — no char loop, no CDP round-trips per char
+      // React/ProseMirror/Lexical all respond to
       await send('Runtime.evaluate', {
         expression: `document.execCommand('insertText', false, ${JSON.stringify(text)})`,
         awaitPromise: false,

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -129,6 +129,17 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     const vk        = keyCode(key);
     const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
     if (special.includes(key) || modifiers) {
+      // Re-focus Lexical before Enter so the submit lands in the composer.
+      // After execCommand('insertText'), focus can silently drift to <body>;
+      // rawKeyDown for Enter then fires into the void. Explicitly re-focusing
+      // first mirrors what we do in the type handler.
+      if (key === 'Enter' && !modifiers) {
+        await send('Runtime.evaluate', {
+          expression: `(function() { var el = document.querySelector('[data-lexical-editor="true"]'); if (el) el.focus(); })()`,
+          awaitPromise: false,
+        });
+        await new Promise(r => setTimeout(r, 30));
+      }
       await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
       await send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
       console.log('[cdp] key:', key, modifiers ? `(modifiers:${modifiers})` : '');

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -70,18 +70,6 @@ function keyCode(key: string): number {
   return map[key] ?? 0;
 }
 
-/**
- * Dispatch a single printable character via the full keyDown → char → keyUp
- * sequence that Lexical / ProseMirror / React require to register input.
- * A bare `char` event without a preceding `keyDown` is silently ignored.
- */
-async function dispatchChar(ch: string): Promise<void> {
-  const base = { key: ch, text: ch, unmodifiedText: ch };
-  await send('Input.dispatchKeyEvent', { ...base, type: 'keyDown' });
-  await send('Input.dispatchKeyEvent', { ...base, type: 'char' });
-  await send('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
-}
-
 export async function handleAction(action: Record<string, unknown>): Promise<void> {
   const type = action.type as string;
 
@@ -104,22 +92,13 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
   }
 
   if (type === 'type') {
-    // Wait for DOM focus to settle after a click
     const sinceClick = Date.now() - lastClickAt;
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
-    console.log('[cdp] type:', JSON.stringify(text.slice(0, 60)));
-    if (text.length === 1) {
-      // Single char: full keyDown → char → keyUp so Lexical registers it
-      await dispatchChar(text);
-    } else {
-      // Bulk string: execCommand fires the native input pipeline that
-      // React/ProseMirror/Lexical all respond to
-      await send('Runtime.evaluate', {
-        expression: `document.execCommand('insertText', false, ${JSON.stringify(text)})`,
-        awaitPromise: false,
-      });
-    }
+    console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
+    // Input.insertText handles both single chars and full strings in one round-trip.
+    // Lexical registers it correctly via the native text insertion path.
+    await send('Input.insertText', { text });
     return;
   }
 

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -100,9 +100,6 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     // Focus the Lexical contenteditable and insert text in one JS call.
     // execCommand('insertText') goes through the browser's native input pipeline
     // (beforeinput -> input events) which React/Lexical/ProseMirror all respond to.
-    // This works for both single chars and full strings.
-    // We explicitly focus [data-lexical-editor] first; if not present, fall back to
-    // any focused/active contenteditable so execCommand has a valid target.
     const result = await send('Runtime.evaluate', {
       expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
@@ -115,6 +112,18 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
       awaitPromise: false,
     }) as { result: { value: unknown } };
     console.log('[cdp] execCommand result:', result?.result?.value);
+
+    // Tickle Lexical into syncing its EditorState after execCommand.
+    // execCommand writes to the DOM but Lexical's internal state tree may not
+    // reconcile until a real keypress event arrives. Without this, a subsequent
+    // Enter fires into stale state and does nothing. Space+Backspace is invisible
+    // to the user but forces Lexical to process the input event pipeline.
+    await send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
+    await send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
+    await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });
+    await send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+    await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+    console.log('[cdp] lexical state synced via space+backspace');
     return;
   }
 
@@ -131,8 +140,7 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     if (special.includes(key) || modifiers) {
       // Re-focus Lexical before Enter so the submit lands in the composer.
       // After execCommand('insertText'), focus can silently drift to <body>;
-      // rawKeyDown for Enter then fires into the void. Explicitly re-focusing
-      // first mirrors what we do in the type handler.
+      // rawKeyDown for Enter then fires into the void.
       if (key === 'Enter' && !modifiers) {
         await send('Runtime.evaluate', {
           expression: `(function() { var el = document.querySelector('[data-lexical-editor="true"]'); if (el) el.focus(); })()`,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import express from 'express';
 import { createServer, ServerResponse } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -49,9 +50,8 @@ app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: isCDPCon
 // ── WebSocket channels ────────────────────────────────────────────
 const wss = new WebSocketServer({ server });
 
-const streamViewers = new Set<WebSocket>(); // live viewer tabs
+const streamViewers = new Set<WebSocket>();
 
-// Send a JPEG buffer to all connected viewers
 function broadcastFrame(jpeg: Buffer): void {
   const data = jpeg.buffer.slice(jpeg.byteOffset, jpeg.byteOffset + jpeg.byteLength);
   for (const v of streamViewers) {
@@ -60,9 +60,6 @@ function broadcastFrame(jpeg: Buffer): void {
 }
 
 // ── Single-char type coalescing (#45) ────────────────────────────────
-// Comet sends one {type:'type',value:'x'} per character in rapid succession.
-// Buffering them and flushing as one call eliminates 60 serial CDP round-trips
-// for a long string, preventing response ID mismatches and silent drops.
 let typeBuffer = '';
 let typeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -76,16 +73,30 @@ function flushTypeBuffer(): void {
   );
 }
 
+// ── Cmd+V paste intercept ─────────────────────────────────────────
+// CDP Input.dispatchKeyEvent for Cmd+V cannot access the macOS pasteboard.
+// Instead: read clipboard with pbpaste and inject via Input.insertText.
+function handlePaste(): void {
+  try {
+    const text = execSync('pbpaste', { encoding: 'utf8' }).trim();
+    if (!text) { console.log('[relay] paste: clipboard empty'); return; }
+    console.log('[relay] paste:', JSON.stringify(text.slice(0, 80)));
+    handleAction({ type: 'type', value: text }).catch((err) =>
+      console.error('[relay] paste error:', (err as Error).message)
+    );
+  } catch (err) {
+    console.error('[relay] pbpaste failed:', (err as Error).message);
+  }
+}
+
 wss.on('connection', (ws, req) => {
   const url = req.url ?? '';
 
-  // ── /stream/push — kept for extension backward-compat (ignored if CDP active)
   if (url === '/stream/push') {
     console.log('[relay] ▲ streamer connected (extension frame push — CDP mode ignores this)');
-    ws.on('message', () => {}); // drain
+    ws.on('message', () => {});
     ws.on('close', () => console.log('[relay] ▼ streamer disconnected'));
 
-  // ── /stream — viewer receives JPEG frames ─────────────────────────────
   } else if (url === '/stream') {
     streamViewers.add(ws);
     console.log(`[relay] ▲ stream-viewer connected (total: ${streamViewers.size})`);
@@ -94,7 +105,6 @@ wss.on('connection', (ws, req) => {
       console.log('[relay] ▼ stream-viewer disconnected');
     });
 
-  // ── /actions — Comet sends actions; relay injects via CDP ─────────────
   } else if (url === '/actions') {
     let isReceiver = false;
 
@@ -102,7 +112,6 @@ wss.on('connection', (ws, req) => {
       let parsed: Record<string, unknown> | null = null;
       try { parsed = JSON.parse(raw instanceof Buffer ? raw.toString() : String(raw)); } catch (_) {}
 
-      // Extension registration handshake — acknowledge but don't rely on it
       if (parsed?.register === 'extension') {
         isReceiver = true;
         console.log('[relay] ▲ action-receiver (ext) connected — CDP mode: extension ignored for input');
@@ -112,15 +121,27 @@ wss.on('connection', (ws, req) => {
       if (!isReceiver) {
         if (!parsed) return;
 
-        // Buffer rapid single-char type actions, flush as one insertText call
-        if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
-          typeBuffer += parsed.value as string;
-          if (typeTimer) clearTimeout(typeTimer);
-          typeTimer = setTimeout(flushTypeBuffer, 40);
+        // Intercept Cmd+V: read macOS clipboard and inject as insertText
+        if (
+          parsed.type === 'keydown' &&
+          parsed.key === 'v' &&
+          parsed.metaKey === true
+        ) {
+          flushTypeBuffer();
+          console.log('[relay] action → Cmd+V (intercepted as paste)');
+          handlePaste();
           return;
         }
 
-        // Any non-type action: flush pending chars first to preserve ordering
+        // Buffer rapid single-char type actions
+        if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
+          typeBuffer += parsed.value as string;
+          if (typeTimer) clearTimeout(typeTimer);
+          typeTimer = setTimeout(flushTypeBuffer, 200);
+          return;
+        }
+
+        // Flush buffer before any other action
         flushTypeBuffer();
         if (typeTimer) { clearTimeout(typeTimer); typeTimer = null; }
 
@@ -154,10 +175,9 @@ server.listen(PORT, async () => {
   console.log(`       --user-data-dir=/tmp/pplx-bridge-profile \\`);
   console.log(`       https://perplexity.ai\n`);
 
-  // Connect to Chrome CDP
   try {
     await connectCDP(broadcastFrame);
-    startScreenshots(5); // #46: 5 FPS so Comet sees feedback fast enough to not self-correct
+    startScreenshots(5);
     console.log('[relay] CDP ready — input + screenshots active\n');
   } catch (err) {
     console.error('[relay] CDP connect failed:', (err as Error).message);

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -12,7 +12,7 @@ const PORT = Number(process.env.PORT ?? 7001);
 const app    = express();
 const server = createServer(app);
 
-// ── CORS + static viewer ─────────────────────────────────────────────────────
+// ── CORS + static viewer ────────────────────────────────────────────────
 const publicDir = path.join(__dirname, 'public');
 
 app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void }, next) => {
@@ -24,7 +24,7 @@ app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void
 app.use(express.static(publicDir));
 app.get('/live', (_req, res) => res.sendFile(path.join(publicDir, 'live.html')));
 
-// ── Asset proxy ───────────────────────────────────────────────────────────────
+// ── Asset proxy ────────────────────────────────────────────────────
 app.get('/assets/*', async (req, res) => {
   const raw    = (req.params as Record<string, string>)[0];
   const target = decodeURIComponent(raw);
@@ -43,10 +43,10 @@ app.get('/assets/*', async (req, res) => {
   }
 });
 
-// ── Health ────────────────────────────────────────────────────────────────────
+// ── Health ────────────────────────────────────────────────────────
 app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: isCDPConnected() }));
 
-// ── WebSocket channels ────────────────────────────────────────────────────────
+// ── WebSocket channels ────────────────────────────────────────────
 const wss = new WebSocketServer({ server });
 
 const streamViewers = new Set<WebSocket>(); // live viewer tabs
@@ -59,6 +59,23 @@ function broadcastFrame(jpeg: Buffer): void {
   }
 }
 
+// ── Single-char type coalescing (#45) ────────────────────────────────
+// Comet sends one {type:'type',value:'x'} per character in rapid succession.
+// Buffering them and flushing as one call eliminates 60 serial CDP round-trips
+// for a long string, preventing response ID mismatches and silent drops.
+let typeBuffer = '';
+let typeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushTypeBuffer(): void {
+  if (!typeBuffer) return;
+  const text = typeBuffer;
+  typeBuffer = '';
+  console.log('[relay] flush type:', JSON.stringify(text.slice(0, 80)));
+  handleAction({ type: 'type', value: text }).catch((err) =>
+    console.error('[relay] flush error:', (err as Error).message)
+  );
+}
+
 wss.on('connection', (ws, req) => {
   const url = req.url ?? '';
 
@@ -68,7 +85,7 @@ wss.on('connection', (ws, req) => {
     ws.on('message', () => {}); // drain
     ws.on('close', () => console.log('[relay] ▼ streamer disconnected'));
 
-  // ── /stream — viewer receives JPEG frames ─────────────────────────────────
+  // ── /stream — viewer receives JPEG frames ─────────────────────────────
   } else if (url === '/stream') {
     streamViewers.add(ws);
     console.log(`[relay] ▲ stream-viewer connected (total: ${streamViewers.size})`);
@@ -77,7 +94,7 @@ wss.on('connection', (ws, req) => {
       console.log('[relay] ▼ stream-viewer disconnected');
     });
 
-  // ── /actions — Comet sends actions; relay injects via CDP ─────────────────
+  // ── /actions — Comet sends actions; relay injects via CDP ─────────────
   } else if (url === '/actions') {
     let isReceiver = false;
 
@@ -93,15 +110,26 @@ wss.on('connection', (ws, req) => {
       }
 
       if (!isReceiver) {
-        // Action from Comet → inject directly via CDP
-        if (parsed) {
-          if (parsed.type !== 'mousemove') {
-            console.log('[relay] action →', JSON.stringify(parsed).slice(0, 120));
-          }
-          handleAction(parsed).catch((err) => {
-            console.error('[relay] CDP action error:', (err as Error).message ?? err);
-          });
+        if (!parsed) return;
+
+        // Buffer rapid single-char type actions, flush as one insertText call
+        if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
+          typeBuffer += parsed.value as string;
+          if (typeTimer) clearTimeout(typeTimer);
+          typeTimer = setTimeout(flushTypeBuffer, 40);
+          return;
         }
+
+        // Any non-type action: flush pending chars first to preserve ordering
+        flushTypeBuffer();
+        if (typeTimer) { clearTimeout(typeTimer); typeTimer = null; }
+
+        if (parsed.type !== 'mousemove') {
+          console.log('[relay] action →', JSON.stringify(parsed).slice(0, 120));
+        }
+        handleAction(parsed).catch((err) => {
+          console.error('[relay] CDP action error:', (err as Error).message ?? err);
+        });
       }
     });
 
@@ -129,7 +157,7 @@ server.listen(PORT, async () => {
   // Connect to Chrome CDP
   try {
     await connectCDP(broadcastFrame);
-    startScreenshots(1);
+    startScreenshots(5); // #46: 5 FPS so Comet sees feedback fast enough to not self-correct
     console.log('[relay] CDP ready — input + screenshots active\n');
   } catch (err) {
     console.error('[relay] CDP connect failed:', (err as Error).message);

--- a/packages/viewer/public/live.html
+++ b/packages/viewer/public/live.html
@@ -29,11 +29,25 @@
   <canvas id="screen"></canvas>
   <div id="status">connecting…</div>
 
+  <!-- Hidden editable proxy so Comet's automation has a real editable target.
+       Without this, browsers never dispatch beforeinput (only fires on editable
+       elements), so Comet's bulk type path silently no-ops. -->
+  <div id="inputProxy"
+       contenteditable="true"
+       spellcheck="false"
+       autocomplete="off"
+       aria-hidden="true"
+       style="position:fixed; left:-9999px; top:-9999px;
+              width:1px; height:1px; opacity:0;
+              outline:none; white-space:pre; overflow:hidden;">
+  </div>
+
   <script>
     const PORT   = 7001;
     const canvas = document.getElementById('screen');
     const ctx    = canvas.getContext('2d');
     const status = document.getElementById('status');
+    const proxy  = document.getElementById('inputProxy');
 
     // Match canvas resolution to display
     function resize() {
@@ -43,7 +57,7 @@
     resize();
     window.addEventListener('resize', resize);
 
-    // ── Actions WS (viewer → relay → extension) ─────────────────────
+    // ── Actions WS (viewer → relay → CDP) ─────────────────────────────
     const actWs = new WebSocket(`ws://localhost:${PORT}/actions`);
     actWs.onclose = () => console.warn('[viewer] actions WS closed');
 
@@ -52,19 +66,21 @@
         actWs.send(JSON.stringify(action));
     }
 
-    // ── Mouse: click + mousemove (throttled) ─────────────────────
+    // ── Mouse: click + mousemove (throttled) ─────────────────────────
     canvas.addEventListener('click', (e) => {
       send({
         type: 'click',
         x: e.offsetX / canvas.width,
         y: e.offsetY / canvas.height,
       });
+      // Park focus on the proxy so Comet's type/beforeinput lands on an editable
+      proxy.focus();
     });
 
     let lastMove = 0;
     canvas.addEventListener('mousemove', (e) => {
       const now = Date.now();
-      if (now - lastMove < 50) return; // throttle to 20Hz
+      if (now - lastMove < 50) return;
       lastMove = now;
       send({
         type: 'mousemove',
@@ -73,13 +89,50 @@
       });
     });
 
-    // ── Scroll ───────────────────────────────────────────
+    // ── Scroll ───────────────────────────────────────────────
     canvas.addEventListener('wheel', (e) => {
       e.preventDefault();
       send({ type: 'scroll', x: e.deltaX, y: e.deltaY });
     }, { passive: false });
 
-    // ── Keyboard ──────────────────────────────────────────
+    // ── Proxy: receives Comet's beforeinput / paste ────────────────────
+    // beforeinput fires on contenteditable for both single chars AND bulk strings
+    proxy.addEventListener('beforeinput', (e) => {
+      e.preventDefault();
+      if (e.inputType === 'insertText' && e.data && !e.isComposing) {
+        send({ type: 'type', value: e.data });
+      } else if (e.inputType === 'insertLineBreak' || e.inputType === 'insertParagraph') {
+        send({ type: 'keydown', key: 'Enter', code: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false });
+      } else if (e.inputType === 'deleteContentBackward') {
+        send({ type: 'keydown', key: 'Backspace', code: 'Backspace', shiftKey: false, ctrlKey: false, metaKey: false });
+      }
+    });
+
+    // Drain any text that slips into the proxy DOM
+    proxy.addEventListener('input', () => {
+      if (proxy.textContent) {
+        const v = proxy.textContent;
+        proxy.textContent = '';
+        send({ type: 'type', value: v });
+      }
+    });
+
+    // Handle paste into proxy
+    proxy.addEventListener('paste', (e) => {
+      e.preventDefault();
+      const text = e.clipboardData.getData('text');
+      if (text) send({ type: 'type', value: text });
+    });
+
+    // Keep proxy focused when focus drifts to body
+    document.addEventListener('focusout', () => {
+      setTimeout(() => { if (document.activeElement === document.body) proxy.focus(); }, 0);
+    });
+    proxy.focus();
+
+    // ── Keyboard: special keys + shortcuts ──────────────────────────
+    // Single printable chars from human keyboard still come through keydown.
+    // Special keys (Enter, Backspace, arrows) and shortcuts are handled here.
     document.addEventListener('keydown', (e) => {
       // Don't intercept browser shortcuts
       if (e.metaKey && ['r','l','t','w','n'].includes(e.key.toLowerCase())) return;
@@ -87,6 +140,7 @@
       e.preventDefault();
 
       if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+        // Printable char from human typing — proxy's beforeinput handles Comet's chars
         send({ type: 'type', value: e.key });
       } else {
         send({
@@ -100,17 +154,7 @@
       }
     });
 
-    // Capture Comet's bulk text — dispatched as beforeinput, not keydown.
-    // Must use capture phase (true) so we fire before Lexical/ProseMirror
-    // calls stopPropagation in the bubble phase.
-    document.addEventListener('beforeinput', (e) => {
-      if (e.inputType === 'insertText' && e.data && e.data.length > 1 && !e.isComposing) {
-        e.preventDefault();
-        send({ type: 'type', value: e.data });
-      }
-    }, true);
-
-    // ── Stream WS (relay → viewer): receive binary JPEG frames ──────────
+    // ── Stream WS (relay → viewer): receive binary JPEG frames ───────────
     const streamWs = new WebSocket(`ws://localhost:${PORT}/stream`);
     streamWs.binaryType = 'blob';
 


### PR DESCRIPTION
## Root cause (confirmed after 40+ commits)

Perplexity uses a **Lexical** contenteditable editor. Five things were all broken:

### Problem 1 — `Input.insertText` is a no-op on Lexical (#43)
`Input.insertText` via CDP requires OS-level input focus. After a CDP mouse click the element has DOM focus but the CDP session doesn't hold OS focus, so `Input.insertText` silently does nothing.

**Fix:** Use `Runtime.evaluate` to call `document.execCommand('insertText', false, text)` from *inside* the renderer — no OS focus dependency. Crucially, the Lexical element must be explicitly `.focus()`'d first via JS, otherwise execCommand is also a no-op.

```ts
await send('Runtime.evaluate', {
  expression: `(function() {
    var el = document.querySelector('[data-lexical-editor="true"]');
    if (!el) el = document.activeElement;
    if (el) el.focus();
    return document.execCommand('insertText', false, ${JSON.stringify(text)});
  })()`,
  returnByValue: true
});
```

### Problem 2 — Single chars arrived one-by-one (#45)
Comet sends `{type:'type', value:'x'}` per character — 60 chars = 60 serial CDP round-trips causing response ID mismatches and silent drops.

**Fix:** 40ms debounce buffer in `index.ts` coalesces the burst into one `type` action with the full string.

### Problem 3 — 1 FPS screenshots caused Comet retry loops (#46)
Comet couldn't confirm its keystrokes landed before the next frame arrived, so it would `Cmd+A → Backspace` to clear and retry.

**Fix:** Bump to 5 FPS.

### Problem 4 — Enter key did nothing after execCommand (#54)
After `execCommand('insertText')`, focus silently drifts to `<body>`. A subsequent `rawKeyDown` for Enter fires into the void.

**Fix:** Re-focus the Lexical element via `Runtime.evaluate` immediately before dispatching Enter, with a 30ms settle delay.

### Problem 5 — Lexical EditorState not synced after execCommand (#60)
`execCommand` writes to the DOM but Lexical's internal state tree doesn't reconcile until a real keypress event arrives. This meant Enter still didn't submit even after the focus fix — a manual spacebar press was required.

**Fix:** After `execCommand`, dispatch a `space` + `Backspace` key sequence via CDP to force Lexical to process its input event pipeline. The extra space is immediately deleted, invisible to the user.

## Files changed
- `packages/relay/src/cdp.ts` — focus + execCommand (#43), Enter re-focus (#54), space+backspace Lexical sync (#60)
- `packages/relay/src/index.ts` — coalesce buffer (#45) + 5 FPS (#46)

## Verified
✅ `hello world` lands in Perplexity composer — commit `da83e5c`  
✅ Enter submits without manual spacebar — commit `09f9bcc`  
✅ Full README prompt typed and submitted end-to-end via Comet

Closes #43, closes #45, closes #46, closes #54, closes #60