### PR TITLE
fix: improve CDP connection resilience

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -9,27 +9,102 @@ let vpW = 1280;
 let vpH = 800;
 let _screenshotCallback: ((jpeg: Buffer) => void) | null = null;
 let lastClickAt = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempts = 0;
+let reconnectInFlight: Promise<void> | null = null;
+let started = false;
+let isConnecting = false;
 
-export async function connectCDP(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
-  _screenshotCallback = screenshotCallback;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 10_000;
+
+function attachSocketLifecycleHandlers(): void {
+  if (!cdpWs) return;
+
+  cdpWs.on('close', () => {
+    console.warn('[cdp] socket closed');
+    cdpWs = null;
+    scheduleReconnect();
+  });
+
+  cdpWs.on('error', (err) => {
+    console.warn('[cdp] socket error:', (err as Error).message);
+  });
+}
+
+async function openCDP(): Promise<void> {
   const res = await fetch('http://localhost:9222/json');
   if (!res.ok) throw new Error('[cdp] Chrome not reachable at localhost:9222');
   const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
   const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
              ?? targets.find(t => t.type === 'page');
   if (!page) throw new Error('[cdp] No page target found.');
-  cdpWs = new WebSocket(page.webSocketDebuggerUrl);
+
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
   await new Promise<void>((resolve, reject) => {
-    cdpWs!.once('open', resolve);
-    cdpWs!.once('error', reject);
+    ws.once('open', resolve);
+    ws.once('error', reject);
   });
+
+  cdpWs = ws;
+  attachSocketLifecycleHandlers();
   await send('Page.enable', {});
   await refreshViewport();
-  console.log(`[cdp] connected \u2192 ${page.url} (viewport ${vpW}x${vpH})`);
+  reconnectAttempts = 0;
+  console.log(`[cdp] connected → ${page.url} (viewport ${vpW}x${vpH})`);
+}
+
+function scheduleReconnect(): void {
+  if (!started || reconnectTimer || reconnectInFlight) return;
+  const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
+  reconnectAttempts += 1;
+  console.log(`[cdp] reconnect scheduled in ${delay}ms`);
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    reconnectCDP().catch((err) => {
+      console.error('[cdp] reconnect failed:', (err as Error).message);
+      scheduleReconnect();
+    });
+  }, delay);
+}
+
+export async function connectCDP(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
+  _screenshotCallback = screenshotCallback;
+  started = true;
+  await reconnectCDP();
+}
+
+export async function reconnectCDP(): Promise<void> {
+  if (reconnectInFlight) return reconnectInFlight;
+  reconnectInFlight = (async () => {
+    isConnecting = true;
+    try {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (cdpWs) {
+        try { cdpWs.removeAllListeners(); } catch {}
+        try { cdpWs.close(); } catch {}
+        cdpWs = null;
+      }
+      await openCDP();
+    } finally {
+      isConnecting = false;
+      reconnectInFlight = null;
+    }
+  })();
+  return reconnectInFlight;
 }
 
 export function isCDPConnected(): boolean {
   return cdpWs?.readyState === WebSocket.OPEN;
+}
+
+export function getCDPState(): 'open' | 'reconnecting' | 'offline' {
+  if (cdpWs?.readyState === WebSocket.OPEN) return 'open';
+  if (isConnecting || reconnectInFlight || reconnectTimer) return 'reconnecting';
+  return 'offline';
 }
 
 function send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
@@ -97,10 +172,6 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
 
-    // Focus the Lexical contenteditable and insert text via execCommand.
-    // execCommand('insertText') is the only trusted insertion path from a CDP session —
-    // synthetic InputEvent/beforeinput dispatched via Runtime.evaluate have isTrusted:false
-    // which Lexical ignores. Input.insertText is a no-op without OS-level focus.
     const result = await send('Runtime.evaluate', {
       expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
@@ -128,12 +199,6 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
     if (special.includes(key) || modifiers) {
       if (key === 'Enter' && !modifiers) {
-        // Sync Lexical EditorState immediately before Enter.
-        // execCommand('insertText') writes to the DOM but Lexical's internal state
-        // tree may not reconcile until a real keypress arrives. A space+backspace
-        // here is invisible to the user but forces Lexical to process the input
-        // event pipeline so the subsequent Enter submit fires correctly.
-        // This is placed on Enter (not on type) so human typing is never affected.
         await send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
         await send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
         await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -4,16 +4,17 @@ import { createServer, ServerResponse } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { connectCDP, handleAction, startScreenshots, isCDPConnected } from './cdp.js';
+import { connectCDP, handleAction, startScreenshots, getCDPState } from './cdp.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = Number(process.env.PORT ?? 7001);
+const STARTUP_RETRY_MS = 2000;
+const STARTUP_MAX_ATTEMPTS = 30;
 
 const app    = express();
 const server = createServer(app);
 
-// ── CORS + static viewer ────────────────────────────────────────────────
 const publicDir = path.join(__dirname, 'public');
 
 app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void }, next) => {
@@ -25,7 +26,6 @@ app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void
 app.use(express.static(publicDir));
 app.get('/live', (_req, res) => res.sendFile(path.join(publicDir, 'live.html')));
 
-// ── Asset proxy ────────────────────────────────────────────────────
 app.get('/assets/*', async (req, res) => {
   const raw    = (req.params as Record<string, string>)[0];
   const target = decodeURIComponent(raw);
@@ -44,10 +44,8 @@ app.get('/assets/*', async (req, res) => {
   }
 });
 
-// ── Health ────────────────────────────────────────────────────────
-app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: isCDPConnected() }));
+app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: getCDPState() }));
 
-// ── WebSocket channels ────────────────────────────────────────────
 const wss = new WebSocketServer({ server });
 
 const streamViewers = new Set<WebSocket>();
@@ -59,7 +57,6 @@ function broadcastFrame(jpeg: Buffer): void {
   }
 }
 
-// ── Single-char type coalescing (#45) ────────────────────────────────
 let typeBuffer = '';
 let typeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -73,9 +70,6 @@ function flushTypeBuffer(): void {
   );
 }
 
-// ── Cmd+V paste intercept ─────────────────────────────────────────
-// CDP Input.dispatchKeyEvent for Cmd+V cannot access the macOS pasteboard.
-// Instead: read clipboard with pbpaste and inject via Input.insertText.
 function handlePaste(): void {
   try {
     const text = execSync('pbpaste', { encoding: 'utf8' }).trim();
@@ -121,7 +115,6 @@ wss.on('connection', (ws, req) => {
       if (!isReceiver) {
         if (!parsed) return;
 
-        // Intercept Cmd+V: read macOS clipboard and inject as insertText
         if (
           parsed.type === 'keydown' &&
           parsed.key === 'v' &&
@@ -133,7 +126,6 @@ wss.on('connection', (ws, req) => {
           return;
         }
 
-        // Buffer rapid single-char type actions
         if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
           typeBuffer += parsed.value as string;
           if (typeTimer) clearTimeout(typeTimer);
@@ -141,7 +133,6 @@ wss.on('connection', (ws, req) => {
           return;
         }
 
-        // Flush buffer before any other action
         flushTypeBuffer();
         if (typeTimer) { clearTimeout(typeTimer); typeTimer = null; }
 
@@ -160,6 +151,25 @@ wss.on('connection', (ws, req) => {
   }
 });
 
+async function connectWithRetry(): Promise<void> {
+  for (let attempt = 1; attempt <= STARTUP_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await connectCDP(broadcastFrame);
+      startScreenshots(5);
+      console.log('[relay] CDP ready — input + screenshots active\n');
+      return;
+    } catch (err) {
+      const message = (err as Error).message;
+      console.error(`[relay] CDP connect failed (attempt ${attempt}/${STARTUP_MAX_ATTEMPTS}):`, message);
+      if (attempt === STARTUP_MAX_ATTEMPTS) {
+        console.error('[relay] CDP unavailable after startup retries; background reconnect remains active\n');
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, STARTUP_RETRY_MS));
+    }
+  }
+}
+
 server.listen(PORT, async () => {
   const w = 44;
   console.log(`\n╔${'═'.repeat(w)}╗`);
@@ -175,12 +185,5 @@ server.listen(PORT, async () => {
   console.log(`       --user-data-dir=/tmp/pplx-bridge-profile \\`);
   console.log(`       https://perplexity.ai\n`);
 
-  try {
-    await connectCDP(broadcastFrame);
-    startScreenshots(5);
-    console.log('[relay] CDP ready — input + screenshots active\n');
-  } catch (err) {
-    console.error('[relay] CDP connect failed:', (err as Error).message);
-    console.error('[relay] Start Chrome with --remote-debugging-port=9222 and restart relay\n');
-  }
+  await connectWithRetry();
 });


### PR DESCRIPTION
Closes #73
Related #71

## What changed
- Added CDP socket lifecycle handling with automatic reconnect scheduling
- Added startup retry loop so relay waits for Chrome instead of failing permanently
- Added `getCDPState()` and updated `/health` to report `open | reconnecting | offline`
- Kept screenshot loop alive so frames resume automatically after reconnect

## Notes
This addresses the current single-shot connection model where the relay enters a dead state if Chrome is unavailable at startup or if the CDP socket drops later.

## Files
- `packages/relay/src/cdp.ts`
- `packages/relay/src/index.ts`