### PR TITLE
feat: multi-session support — CDPSession + RelaySession classes, N-port entry point

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -1,196 +1,204 @@
 /**
- * cdp.ts — direct Chrome DevTools Protocol client.
+ * cdp.ts — Chrome DevTools Protocol client, encapsulated as CDPSession.
+ * Instantiate one CDPSession per relay port / Chrome debug port pair.
  */
 import { WebSocket } from 'ws';
 
-let cdpWs: WebSocket | null = null;
-let msgId = 1;
-let vpW = 1280;
-let vpH = 800;
-let _screenshotCallback: ((jpeg: Buffer) => void) | null = null;
-let lastClickAt = 0;
-let _reconnectHandler: (() => void) | null = null;
-let _didSignalDisconnect = false;
+export class CDPSession {
+  private cdpWs: WebSocket | null = null;
+  private msgId = 1;
+  private vpW = 1280;
+  private vpH = 800;
+  private screenshotCallback: ((jpeg: Buffer) => void) | null = null;
+  private lastClickAt = 0;
+  private reconnectHandler: (() => void) | null = null;
+  private didSignalDisconnect = false;
+  private screenshotInterval = 0;
+  readonly cdpPort: number;
 
-export function setCDPReconnectHandler(handler: () => void): void {
-  _reconnectHandler = handler;
-}
+  constructor(cdpPort = 9222) {
+    this.cdpPort = cdpPort;
+  }
 
-function signalDisconnect(): void {
-  if (_didSignalDisconnect) return;
-  _didSignalDisconnect = true;
-  cdpWs = null;
-  _reconnectHandler?.();
-}
+  setReconnectHandler(handler: () => void): void {
+    this.reconnectHandler = handler;
+  }
 
-function attachLifecycle(ws: WebSocket): void {
-  ws.on('close', () => {
-    console.log('[cdp] socket closed');
-    signalDisconnect();
-  });
-  ws.on('error', (err) => {
-    console.error('[cdp] socket error:', (err as Error).message);
-    signalDisconnect();
-  });
-}
+  private signalDisconnect(): void {
+    if (this.didSignalDisconnect) return;
+    this.didSignalDisconnect = true;
+    this.cdpWs = null;
+    this.reconnectHandler?.();
+  }
 
-export async function connectCDP(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
-  _screenshotCallback = screenshotCallback;
-  const res = await fetch('http://localhost:9222/json');
-  if (!res.ok) throw new Error('[cdp] Chrome not reachable at localhost:9222');
-  const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
-  const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
-             ?? targets.find(t => t.type === 'page');
-  if (!page) throw new Error('[cdp] No page target found.');
-  const ws = new WebSocket(page.webSocketDebuggerUrl);
-  await new Promise<void>((resolve, reject) => {
-    ws.once('open', resolve);
-    ws.once('error', reject);
-  });
-  cdpWs = ws;
-  _didSignalDisconnect = false;
-  attachLifecycle(ws);
-  await send('Page.enable', {});
-  await refreshViewport();
-  console.log(`[cdp] connected → ${page.url} (viewport ${vpW}x${vpH})`);
-}
-
-export function isCDPConnected(): boolean {
-  return cdpWs?.readyState === WebSocket.OPEN;
-}
-
-function send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    if (!cdpWs || cdpWs.readyState !== WebSocket.OPEN) return reject(new Error('[cdp] not connected'));
-    const ws = cdpWs;
-    const id = msgId++;
-    const onMsg = (data: Buffer) => {
-      let msg: Record<string, unknown>;
-      try { msg = JSON.parse(data.toString()); } catch { return; }
-      if (msg.id !== id) return;
-      ws.off('message', onMsg);
-      if (msg.error) reject(msg.error); else resolve(msg.result);
-    };
-    ws.on('message', onMsg);
-    ws.send(JSON.stringify({ id, method, params }), (err) => {
-      if (!err) return;
-      ws.off('message', onMsg);
-      reject(err);
+  private attachLifecycle(ws: WebSocket): void {
+    ws.on('close', () => {
+      console.log(`[cdp:${this.cdpPort}] socket closed`);
+      this.signalDisconnect();
     });
-  });
-}
-
-async function refreshViewport(): Promise<void> {
-  try {
-    const layout = await send('Page.getLayoutMetrics') as Record<string, Record<string, number>>;
-    const vp = layout.cssVisualViewport ?? layout.cssLayoutViewport;
-    vpW = vp?.clientWidth  ?? 1280;
-    vpH = vp?.clientHeight ?? 800;
-  } catch { /* keep cached */ }
-}
-
-function coords(nx: number, ny: number) {
-  return { x: Math.round(nx * vpW), y: Math.round(ny * vpH) };
-}
-
-function keyCode(key: string): number {
-  const map: Record<string, number> = {
-    Enter: 13, Backspace: 8, Tab: 9, Escape: 27,
-    ArrowLeft: 37, ArrowUp: 38, ArrowRight: 39, ArrowDown: 40,
-    Delete: 46, Home: 36, End: 35,
-  };
-  return map[key] ?? 0;
-}
-
-export async function handleAction(action: Record<string, unknown>): Promise<void> {
-  const type = action.type as string;
-
-  if (type === 'mousemove') {
-    const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    return;
+    ws.on('error', (err) => {
+      console.error(`[cdp:${this.cdpPort}] socket error:`, (err as Error).message);
+      this.signalDisconnect();
+    });
   }
 
-  if (type === 'click') {
-    const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    await new Promise(r => setTimeout(r, 80));
-    await send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
-    await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
-    lastClickAt = Date.now();
-    setTimeout(() => refreshViewport(), 600);
-    console.log('[cdp] click at', x, y);
-    return;
+  async connect(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
+    this.screenshotCallback = screenshotCallback;
+    const res = await fetch(`http://localhost:${this.cdpPort}/json`);
+    if (!res.ok) throw new Error(`[cdp:${this.cdpPort}] Chrome not reachable at localhost:${this.cdpPort}`);
+    const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
+    const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
+               ?? targets.find(t => t.type === 'page');
+    if (!page) throw new Error(`[cdp:${this.cdpPort}] No page target found.`);
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+    this.cdpWs = ws;
+    this.didSignalDisconnect = false;
+    this.attachLifecycle(ws);
+    await this.send('Page.enable', {});
+    await this.refreshViewport();
+    console.log(`[cdp:${this.cdpPort}] connected → ${page.url} (viewport ${this.vpW}x${this.vpH})`);
   }
 
-  if (type === 'type') {
-    const sinceClick = Date.now() - lastClickAt;
-    if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
-    const text = action.value as string;
-    console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
-    const result = await send('Runtime.evaluate', {
-      expression: `(function() {
+  isConnected(): boolean {
+    return this.cdpWs?.readyState === WebSocket.OPEN;
+  }
+
+  private send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.cdpWs || this.cdpWs.readyState !== WebSocket.OPEN)
+        return reject(new Error(`[cdp:${this.cdpPort}] not connected`));
+      const ws = this.cdpWs;
+      const id = this.msgId++;
+      const onMsg = (data: Buffer) => {
+        let msg: Record<string, unknown>;
+        try { msg = JSON.parse(data.toString()); } catch { return; }
+        if (msg.id !== id) return;
+        ws.off('message', onMsg);
+        if (msg.error) reject(msg.error); else resolve(msg.result);
+      };
+      ws.on('message', onMsg);
+      ws.send(JSON.stringify({ id, method, params }), (err) => {
+        if (!err) return;
+        ws.off('message', onMsg);
+        reject(err);
+      });
+    });
+  }
+
+  private async refreshViewport(): Promise<void> {
+    try {
+      const layout = await this.send('Page.getLayoutMetrics') as Record<string, Record<string, number>>;
+      const vp = layout.cssVisualViewport ?? layout.cssLayoutViewport;
+      this.vpW = vp?.clientWidth  ?? 1280;
+      this.vpH = vp?.clientHeight ?? 800;
+    } catch { /* keep cached */ }
+  }
+
+  private coords(nx: number, ny: number) {
+    return { x: Math.round(nx * this.vpW), y: Math.round(ny * this.vpH) };
+  }
+
+  private keyCode(key: string): number {
+    const map: Record<string, number> = {
+      Enter: 13, Backspace: 8, Tab: 9, Escape: 27,
+      ArrowLeft: 37, ArrowUp: 38, ArrowRight: 39, ArrowDown: 40,
+      Delete: 46, Home: 36, End: 35,
+    };
+    return map[key] ?? 0;
+  }
+
+  async handleAction(action: Record<string, unknown>): Promise<void> {
+    const type = action.type as string;
+
+    if (type === 'mousemove') {
+      const { x, y } = this.coords(action.x as number, action.y as number);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+      return;
+    }
+
+    if (type === 'click') {
+      const { x, y } = this.coords(action.x as number, action.y as number);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+      await new Promise(r => setTimeout(r, 80));
+      await this.send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
+      this.lastClickAt = Date.now();
+      setTimeout(() => this.refreshViewport(), 600);
+      console.log(`[cdp:${this.cdpPort}] click at`, x, y);
+      return;
+    }
+
+    if (type === 'type') {
+      const sinceClick = Date.now() - this.lastClickAt;
+      if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
+      const text = action.value as string;
+      console.log(`[cdp:${this.cdpPort}] type:`, JSON.stringify(text.slice(0, 80)));
+      const result = await this.send('Runtime.evaluate', {
+        expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
   if (!el) el = document.activeElement;
   if (el) { el.focus(); }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;
 })()`,
-      returnByValue: true,
-      awaitPromise: false,
-    }) as { result: { value: unknown } };
-    console.log('[cdp] execCommand result:', result?.result?.value);
-    return;
-  }
-
-  if (type === 'keydown') {
-    const key = action.key as string;
-    if (['Meta', 'Shift', 'Control', 'Alt'].includes(key)) return;
-    const code      = (action.code as string) ?? key;
-    const shift     = Boolean(action.shiftKey);
-    const ctrl      = Boolean(action.ctrlKey);
-    const meta      = Boolean(action.metaKey);
-    const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
-    const vk        = keyCode(key);
-    const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
-    if (special.includes(key) || modifiers) {
-      if (key === 'Enter' && !modifiers) {
-        await send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
-        await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
-      }
-      await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-      await send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-      console.log('[cdp] key:', key, modifiers ? `(modifiers:${modifiers})` : '');
+        returnByValue: true,
+        awaitPromise: false,
+      }) as { result: { value: unknown } };
+      console.log(`[cdp:${this.cdpPort}] execCommand result:`, result?.result?.value);
+      return;
     }
-    return;
+
+    if (type === 'keydown') {
+      const key = action.key as string;
+      if (['Meta', 'Shift', 'Control', 'Alt'].includes(key)) return;
+      const code      = (action.code as string) ?? key;
+      const shift     = Boolean(action.shiftKey);
+      const ctrl      = Boolean(action.ctrlKey);
+      const meta      = Boolean(action.metaKey);
+      const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
+      const vk        = this.keyCode(key);
+      const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
+      if (special.includes(key) || modifiers) {
+        if (key === 'Enter' && !modifiers) {
+          await this.send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyUp',   key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+        }
+        await this.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
+        await this.send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
+        console.log(`[cdp:${this.cdpPort}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
+      }
+      return;
+    }
+
+    if (type === 'scroll') {
+      const { x, y } = this.coords(0.5, 0.5);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100 });
+      return;
+    }
   }
 
-  if (type === 'scroll') {
-    const { x, y } = coords(0.5, 0.5);
-    await send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100 });
-    return;
+  startScreenshots(fps = 1): void {
+    if (this.screenshotInterval) return;
+    let busy = false;
+    this.screenshotInterval = setInterval(async () => {
+      if (busy || !this.isConnected()) return;
+      busy = true;
+      try {
+        const result = await this.send('Page.captureScreenshot', { format: 'jpeg', quality: 60, fromSurface: true }) as { data: string };
+        if (this.screenshotCallback) this.screenshotCallback(Buffer.from(result.data, 'base64'));
+      } catch { /* ignore */ } finally { busy = false; }
+    }, Math.round(1000 / fps)) as unknown as number;
   }
-}
 
-let screenshotInterval = 0;
-
-export function startScreenshots(fps = 1): void {
-  if (screenshotInterval) return;
-  let busy = false;
-  screenshotInterval = setInterval(async () => {
-    if (busy || !isCDPConnected()) return;
-    busy = true;
-    try {
-      const result = await send('Page.captureScreenshot', { format: 'jpeg', quality: 60, fromSurface: true }) as { data: string };
-      if (_screenshotCallback) _screenshotCallback(Buffer.from(result.data, 'base64'));
-    } catch { /* ignore */ } finally { busy = false; }
-  }, Math.round(1000 / fps)) as unknown as number;
-}
-
-export function stopScreenshots(): void {
-  clearInterval(screenshotInterval);
-  screenshotInterval = 0;
+  stopScreenshots(): void {
+    clearInterval(this.screenshotInterval);
+    this.screenshotInterval = 0;
+  }
 }

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,276 +1,315 @@
 import { execSync } from 'child_process';
 import express from 'express';
-import { createServer, ServerResponse } from 'http';
+import { createServer } from 'http';
+import { ServerResponse } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { connectCDP, handleAction, startScreenshots, stopScreenshots, isCDPConnected, setCDPReconnectHandler } from './cdp.js';
+import { CDPSession } from './cdp.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.join(__dirname, 'public');
 
-const PORT = Number(process.env.PORT ?? 7001);
-const SCREENSHOT_FPS = 5;
+const SCREENSHOT_FPS   = 5;
 const RECONNECT_BASE_MS = 1000;
-const RECONNECT_MAX_MS = 30_000;
+const RECONNECT_MAX_MS  = 30_000;
 const QUEUED_ACTION_MAX = 20;
 const QUEUED_ACTION_TTL_MS = 10_000;
 
-const app    = express();
-const server = createServer(app);
+type QueuedAction = { action: Record<string, unknown>; expiresAt: number };
 
-const publicDir = path.join(__dirname, 'public');
+class RelaySession {
+  private readonly port: number;
+  private readonly cdp: CDPSession;
 
-app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void }, next) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  next();
-});
+  private typeBuffer = '';
+  private typeTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelayMs = RECONNECT_BASE_MS;
+  private reconnectInFlight = false;
+  private readonly queuedActions: QueuedAction[] = [];
+  private readonly streamViewers = new Set<WebSocket>();
 
-app.use(express.static(publicDir));
-app.get('/live', (_req, res) => res.sendFile(path.join(publicDir, 'live.html')));
-
-app.get('/assets/*', async (req, res) => {
-  const raw    = (req.params as Record<string, string>)[0];
-  const target = decodeURIComponent(raw);
-  if (!target.startsWith('https://')) { res.status(400).send('only https:// targets allowed'); return; }
-  try {
-    const upstream = await fetch(target, { headers: { 'User-Agent': 'pplx-bridge/0.1 asset-proxy' } });
-    const ct = upstream.headers.get('content-type');
-    if (ct) res.setHeader('content-type', ct);
-    res.removeHeader('content-security-policy');
-    res.removeHeader('x-frame-options');
-    res.removeHeader('cross-origin-resource-policy');
-    res.send(Buffer.from(await upstream.arrayBuffer()));
-  } catch (err) {
-    console.error('[relay] asset proxy error:', err);
-    res.status(502).send('proxy error');
+  constructor(port: number, cdpPort: number) {
+    this.port = port;
+    this.cdp  = new CDPSession(cdpPort);
+    this.cdp.setReconnectHandler(() => this.scheduleReconnect());
   }
-});
 
-app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: isCDPConnected() }));
+  // ── Helpers ───────────────────────────────────────────────────────────
 
-const wss = new WebSocketServer({ server });
-const streamViewers = new Set<WebSocket>();
-
-function broadcastFrame(jpeg: Buffer): void {
-  const data = jpeg.buffer.slice(jpeg.byteOffset, jpeg.byteOffset + jpeg.byteLength);
-  for (const v of streamViewers) {
-    if (v.readyState === WebSocket.OPEN) v.send(data, { binary: true });
-  }
-}
-
-let typeBuffer = '';
-let typeTimer: ReturnType<typeof setTimeout> | null = null;
-
-function flushTypeBuffer(): string {
-  if (!typeBuffer) return '';
-  const text = typeBuffer;
-  typeBuffer = '';
-  if (typeTimer) {
-    clearTimeout(typeTimer);
-    typeTimer = null;
-  }
-  console.log('[relay] flush type:', JSON.stringify(text.slice(0, 80)));
-  return text;
-}
-
-function handlePaste(): void {
-  try {
-    const text = execSync('pbpaste', { encoding: 'utf8' }).trim();
-    if (!text) { console.log('[relay] paste: clipboard empty'); return; }
-    console.log('[relay] paste:', JSON.stringify(text.slice(0, 80)));
-    enqueueOrRunAction({ type: 'type', value: text });
-  } catch (err) {
-    console.error('[relay] pbpaste failed:', (err as Error).message);
-  }
-}
-
-type QueuedAction = {
-  action: Record<string, unknown>;
-  expiresAt: number;
-};
-
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let reconnectDelayMs = RECONNECT_BASE_MS;
-let reconnectInFlight = false;
-const queuedActions: QueuedAction[] = [];
-
-function pruneQueuedActions(): void {
-  const now = Date.now();
-  while (queuedActions.length && queuedActions[0]!.expiresAt <= now) queuedActions.shift();
-}
-
-function queueAction(action: Record<string, unknown>): void {
-  pruneQueuedActions();
-  if (queuedActions.length >= QUEUED_ACTION_MAX) queuedActions.shift();
-  queuedActions.push({ action, expiresAt: Date.now() + QUEUED_ACTION_TTL_MS });
-  console.log('[relay] queued action while disconnected:', JSON.stringify(action).slice(0, 120));
-}
-
-async function runAction(action: Record<string, unknown>): Promise<void> {
-  try {
-    await handleAction(action);
-  } catch (err) {
-    if ((err as Error).message?.includes('not connected')) {
-      queueAction(action);
-      scheduleReconnect();
-      return;
+  private broadcastFrame(jpeg: Buffer): void {
+    const data = jpeg.buffer.slice(jpeg.byteOffset, jpeg.byteOffset + jpeg.byteLength);
+    for (const v of this.streamViewers) {
+      if (v.readyState === WebSocket.OPEN) v.send(data, { binary: true });
     }
-    console.error('[relay] CDP action error:', (err as Error).message ?? err);
   }
-}
 
-function enqueueOrRunAction(action: Record<string, unknown>): void {
-  if (!isCDPConnected()) {
-    queueAction(action);
-    scheduleReconnect();
-    return;
+  private flushTypeBuffer(): string {
+    if (!this.typeBuffer) return '';
+    const text = this.typeBuffer;
+    this.typeBuffer = '';
+    if (this.typeTimer) { clearTimeout(this.typeTimer); this.typeTimer = null; }
+    console.log(`[relay:${this.port}] flush type:`, JSON.stringify(text.slice(0, 80)));
+    return text;
   }
-  runAction(action).catch((err) => {
-    console.error('[relay] action pipeline error:', (err as Error).message ?? err);
-  });
-}
 
-async function flushQueuedActions(): Promise<void> {
-  pruneQueuedActions();
-  while (queuedActions.length && isCDPConnected()) {
-    const next = queuedActions.shift();
-    if (!next || next.expiresAt <= Date.now()) continue;
-    await runAction(next.action);
+  private handlePaste(): void {
+    try {
+      const text = execSync('pbpaste', { encoding: 'utf8' }).trim();
+      if (!text) { console.log(`[relay:${this.port}] paste: clipboard empty`); return; }
+      console.log(`[relay:${this.port}] paste:`, JSON.stringify(text.slice(0, 80)));
+      this.enqueueOrRunAction({ type: 'type', value: text });
+    } catch (err) {
+      console.error(`[relay:${this.port}] pbpaste failed:`, (err as Error).message);
+    }
   }
-}
 
-async function reconnectCDP(): Promise<void> {
-  if (reconnectInFlight || isCDPConnected()) return;
-  reconnectInFlight = true;
-  stopScreenshots();
-  try {
-    console.log('[relay] reconnecting CDP...');
-    await connectCDP(broadcastFrame);
-    startScreenshots(SCREENSHOT_FPS);
-    console.log('[relay] CDP reconnected');
-    await flushQueuedActions();
-    // Reset backoff only after flush succeeds — so a bad-flush loop stays throttled
-    reconnectDelayMs = RECONNECT_BASE_MS;
-  } catch (err) {
-    console.error('[relay] reconnect failed:', (err as Error).message);
-    scheduleReconnect();
-  } finally {
-    reconnectInFlight = false;
+  // ── Action queue ──────────────────────────────────────────────────────
+
+  private pruneQueuedActions(): void {
+    const now = Date.now();
+    while (this.queuedActions.length && this.queuedActions[0]!.expiresAt <= now)
+      this.queuedActions.shift();
   }
-}
 
-function scheduleReconnect(): void {
-  if (isCDPConnected() || reconnectTimer || reconnectInFlight) return;
-  const delay = reconnectDelayMs;
-  console.log(`[relay] scheduling reconnect in ${delay}ms`);
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    reconnectCDP().catch((err) => {
-      console.error('[relay] reconnect pipeline error:', (err as Error).message ?? err);
-    });
-  }, delay);
-  reconnectDelayMs = Math.min(reconnectDelayMs * 2, RECONNECT_MAX_MS);
-}
+  private queueAction(action: Record<string, unknown>): void {
+    this.pruneQueuedActions();
+    if (this.queuedActions.length >= QUEUED_ACTION_MAX) this.queuedActions.shift();
+    this.queuedActions.push({ action, expiresAt: Date.now() + QUEUED_ACTION_TTL_MS });
+    console.log(`[relay:${this.port}] queued action:`, JSON.stringify(action).slice(0, 120));
+  }
 
-// stopScreenshots is handled inside reconnectCDP; no need to call it here too
-setCDPReconnectHandler(() => {
-  scheduleReconnect();
-});
-
-wss.on('connection', (ws, req) => {
-  const url = req.url ?? '';
-
-  if (url === '/stream/push') {
-    console.log('[relay] ▲ streamer connected (extension frame push — CDP mode ignores this)');
-    ws.on('message', () => {});
-    ws.on('close', () => console.log('[relay] ▼ streamer disconnected'));
-
-  } else if (url === '/stream') {
-    streamViewers.add(ws);
-    console.log(`[relay] ▲ stream-viewer connected (total: ${streamViewers.size})`);
-    ws.on('close', () => {
-      streamViewers.delete(ws);
-      console.log('[relay] ▼ stream-viewer disconnected');
-    });
-
-  } else if (url === '/actions') {
-    let isReceiver = false;
-
-    ws.on('message', (raw) => {
-      let parsed: Record<string, unknown> | null = null;
-      try { parsed = JSON.parse(raw instanceof Buffer ? raw.toString() : String(raw)); } catch (_) {}
-
-      if (parsed?.register === 'extension') {
-        isReceiver = true;
-        console.log('[relay] ▲ action-receiver (ext) connected — CDP mode: extension ignored for input');
+  private async runAction(action: Record<string, unknown>): Promise<void> {
+    try {
+      await this.cdp.handleAction(action);
+    } catch (err) {
+      if ((err as Error).message?.includes('not connected')) {
+        this.queueAction(action);
+        this.scheduleReconnect();
         return;
       }
+      console.error(`[relay:${this.port}] CDP action error:`, (err as Error).message ?? err);
+    }
+  }
 
-      if (!isReceiver) {
-        if (!parsed) return;
+  private enqueueOrRunAction(action: Record<string, unknown>): void {
+    if (!this.cdp.isConnected()) {
+      this.queueAction(action);
+      this.scheduleReconnect();
+      return;
+    }
+    this.runAction(action).catch((err) =>
+      console.error(`[relay:${this.port}] action pipeline error:`, (err as Error).message ?? err)
+    );
+  }
 
-        if (
-          parsed.type === 'keydown' &&
-          parsed.key === 'v' &&
-          parsed.metaKey === true
-        ) {
-          const buffered = flushTypeBuffer();
-          if (buffered) enqueueOrRunAction({ type: 'type', value: buffered });
-          console.log('[relay] action → Cmd+V (intercepted as paste)');
-          handlePaste();
-          return;
-        }
+  private async flushQueuedActions(): Promise<void> {
+    this.pruneQueuedActions();
+    while (this.queuedActions.length && this.cdp.isConnected()) {
+      const next = this.queuedActions.shift();
+      if (!next || next.expiresAt <= Date.now()) continue;
+      await this.runAction(next.action);
+    }
+  }
 
-        if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
-          typeBuffer += parsed.value as string;
-          if (typeTimer) clearTimeout(typeTimer);
-          typeTimer = setTimeout(() => {
-            const buffered = flushTypeBuffer();
-            if (buffered) enqueueOrRunAction({ type: 'type', value: buffered });
-          }, 200);
-          return;
-        }
+  // ── Reconnect ─────────────────────────────────────────────────────────
 
-        const buffered = flushTypeBuffer();
-        if (buffered) enqueueOrRunAction({ type: 'type', value: buffered });
+  private async reconnectCDP(): Promise<void> {
+    if (this.reconnectInFlight || this.cdp.isConnected()) return;
+    this.reconnectInFlight = true;
+    this.cdp.stopScreenshots();
+    try {
+      console.log(`[relay:${this.port}] reconnecting CDP...`);
+      await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+      this.cdp.startScreenshots(SCREENSHOT_FPS);
+      console.log(`[relay:${this.port}] CDP reconnected`);
+      await this.flushQueuedActions();
+      this.reconnectDelayMs = RECONNECT_BASE_MS;
+    } catch (err) {
+      console.error(`[relay:${this.port}] reconnect failed:`, (err as Error).message);
+      this.scheduleReconnect();
+    } finally {
+      this.reconnectInFlight = false;
+    }
+  }
 
-        if (parsed.type !== 'mousemove') {
-          console.log('[relay] action →', JSON.stringify(parsed).slice(0, 120));
-        }
-        enqueueOrRunAction(parsed);
+  private scheduleReconnect(): void {
+    if (this.cdp.isConnected() || this.reconnectTimer || this.reconnectInFlight) return;
+    const delay = this.reconnectDelayMs;
+    console.log(`[relay:${this.port}] scheduling reconnect in ${delay}ms`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectCDP().catch((err) =>
+        console.error(`[relay:${this.port}] reconnect pipeline error:`, (err as Error).message ?? err)
+      );
+    }, delay);
+    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, RECONNECT_MAX_MS);
+  }
+
+  // ── Start ─────────────────────────────────────────────────────────────
+
+  start(): void {
+    const app    = express();
+    const server = createServer(app);
+    const wss    = new WebSocketServer({ server });
+
+    app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void }, next) => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      next();
+    });
+
+    app.use(express.static(publicDir));
+    app.get('/live', (_req, res) => res.sendFile(path.join(publicDir, 'live.html')));
+
+    app.get('/assets/*', async (req, res) => {
+      const raw    = (req.params as Record<string, string>)[0];
+      const target = decodeURIComponent(raw);
+      if (!target.startsWith('https://')) { res.status(400).send('only https:// targets allowed'); return; }
+      try {
+        const upstream = await fetch(target, { headers: { 'User-Agent': 'pplx-bridge/0.1 asset-proxy' } });
+        const ct = upstream.headers.get('content-type');
+        if (ct) res.setHeader('content-type', ct);
+        res.removeHeader('content-security-policy');
+        res.removeHeader('x-frame-options');
+        res.removeHeader('cross-origin-resource-policy');
+        res.send(Buffer.from(await upstream.arrayBuffer()));
+      } catch (err) {
+        console.error(`[relay:${this.port}] asset proxy error:`, err);
+        res.status(502).send('proxy error');
       }
     });
 
-    ws.on('close', () => {
-      if (isReceiver) console.log('[relay] ▼ action-receiver (ext) disconnected');
+    app.get('/health', (_req, res) =>
+      res.json({ ok: true, port: this.port, cdpPort: this.cdp.cdpPort, cdp: this.cdp.isConnected() })
+    );
+
+    wss.on('connection', (ws, req) => {
+      const url = req.url ?? '';
+
+      if (url === '/stream/push') {
+        console.log(`[relay:${this.port}] ▲ streamer connected`);
+        ws.on('message', () => {});
+        ws.on('close', () => console.log(`[relay:${this.port}] ▼ streamer disconnected`));
+
+      } else if (url === '/stream') {
+        this.streamViewers.add(ws);
+        console.log(`[relay:${this.port}] ▲ stream-viewer connected (total: ${this.streamViewers.size})`);
+        ws.on('close', () => {
+          this.streamViewers.delete(ws);
+          console.log(`[relay:${this.port}] ▼ stream-viewer disconnected`);
+        });
+
+      } else if (url === '/actions') {
+        let isReceiver = false;
+
+        ws.on('message', (raw) => {
+          let parsed: Record<string, unknown> | null = null;
+          try { parsed = JSON.parse(raw instanceof Buffer ? raw.toString() : String(raw)); } catch (_) {}
+
+          if (parsed?.register === 'extension') {
+            isReceiver = true;
+            console.log(`[relay:${this.port}] ▲ action-receiver (ext) connected`);
+            return;
+          }
+
+          if (!isReceiver) {
+            if (!parsed) return;
+
+            if (parsed.type === 'keydown' && parsed.key === 'v' && parsed.metaKey === true) {
+              const buffered = this.flushTypeBuffer();
+              if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+              console.log(`[relay:${this.port}] action → Cmd+V (intercepted as paste)`);
+              this.handlePaste();
+              return;
+            }
+
+            if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
+              this.typeBuffer += parsed.value as string;
+              if (this.typeTimer) clearTimeout(this.typeTimer);
+              this.typeTimer = setTimeout(() => {
+                const buffered = this.flushTypeBuffer();
+                if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+              }, 200);
+              return;
+            }
+
+            const buffered = this.flushTypeBuffer();
+            if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+
+            if (parsed.type !== 'mousemove')
+              console.log(`[relay:${this.port}] action →`, JSON.stringify(parsed).slice(0, 120));
+
+            this.enqueueOrRunAction(parsed);
+          }
+        });
+
+        ws.on('close', () => {
+          if (isReceiver) console.log(`[relay:${this.port}] ▼ action-receiver (ext) disconnected`);
+        });
+      }
+    });
+
+    server.listen(this.port, async () => {
+      const w = 44;
+      console.log(`\n╔${'═'.repeat(w)}╗`);
+      console.log(`║  pplx-bridge relay  →  localhost:${this.port}${' '.repeat(w - 28 - String(this.port).length)}║`);
+      console.log(`╚${'═'.repeat(w)}╝`);
+      console.log(`  Stream view  ws://localhost:${this.port}/stream`);
+      console.log(`  Actions      ws://localhost:${this.port}/actions`);
+      console.log(`  Viewer       http://localhost:${this.port}/live`);
+      console.log(`  Health       http://localhost:${this.port}/health`);
+      console.log(`  CDP port     ${this.cdp.cdpPort}\n`);
+      console.log(`  ⚠️  Start Chrome with:`);
+      console.log(`     /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \\`);
+      console.log(`       --remote-debugging-port=${this.cdp.cdpPort} \\`);
+      console.log(`       --user-data-dir=/tmp/pplx-bridge-${this.cdp.cdpPort} \\`);
+      console.log(`       https://perplexity.ai\n`);
+
+      try {
+        await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+        this.reconnectDelayMs = RECONNECT_BASE_MS;
+        this.cdp.startScreenshots(SCREENSHOT_FPS);
+        console.log(`[relay:${this.port}] CDP ready — input + screenshots active\n`);
+      } catch (err) {
+        console.error(`[relay:${this.port}] CDP connect failed:`, (err as Error).message);
+        console.error(`[relay:${this.port}] Start Chrome with --remote-debugging-port=${this.cdp.cdpPort}\n`);
+        this.scheduleReconnect();
+      }
     });
   }
-});
+}
 
-server.listen(PORT, async () => {
-  const w = 44;
-  console.log(`\n╔${'═'.repeat(w)}╗`);
-  console.log(`║  pplx-bridge relay  →  localhost:${PORT}${' '.repeat(w - 28 - String(PORT).length)}║`);
-  console.log(`╚${'═'.repeat(w)}╝`);
-  console.log(`  Stream view  ws://localhost:${PORT}/stream`);
-  console.log(`  Actions      ws://localhost:${PORT}/actions`);
-  console.log(`  Viewer       http://localhost:${PORT}/live`);
-  console.log(`  Health       http://localhost:${PORT}/health\n`);
-  console.log(`  ⚠️  Start Chrome with:`);
-  console.log(`     /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\`);
-  console.log(`       --remote-debugging-port=9222 \\`);
-  console.log(`       --user-data-dir=/tmp/pplx-bridge-profile \\`);
-  console.log(`       https://perplexity.ai\n`);
+/**
+ * Parse session pairs from argv or env.
+ *
+ * Usage:
+ *   node dist/index.js                     → single session port=7001 cdp=9222
+ *   node dist/index.js 7001 7002 7003       → three sessions, cdp ports 9222/9223/9224
+ *   PORT=7002 CDP_PORT=9223 node dist/index.js  → single session (env, backward-compat)
+ *   node dist/index.js 7001:9222 7002:9223  → explicit relay:cdp pairs
+ */
+function parseSessionArgs(): Array<{ port: number; cdpPort: number }> {
+  const args = process.argv.slice(2);
 
-  try {
-    await connectCDP(broadcastFrame);
-    reconnectDelayMs = RECONNECT_BASE_MS;
-    startScreenshots(SCREENSHOT_FPS);
-    console.log('[relay] CDP ready — input + screenshots active\n');
-  } catch (err) {
-    console.error('[relay] CDP connect failed:', (err as Error).message);
-    console.error('[relay] Start Chrome with --remote-debugging-port=9222 and restart relay\n');
-    scheduleReconnect();
+  if (args.length > 0) {
+    return args.map((arg) => {
+      if (arg.includes(':')) {
+        const [p, c] = arg.split(':').map(Number);
+        return { port: p!, cdpPort: c! };
+      }
+      const port = Number(arg);
+      return { port, cdpPort: 9222 + (port - 7001) };
+    });
   }
-});
+
+  // env / defaults (backward-compatible)
+  const port    = Number(process.env.PORT     ?? 7001);
+  const cdpPort = Number(process.env.CDP_PORT ?? 9222 + (port - 7001));
+  return [{ port, cdpPort }];
+}
+
+for (const { port, cdpPort } of parseSessionArgs()) {
+  new RelaySession(port, cdpPort).start();
+}


### PR DESCRIPTION
## What

Refactors `cdp.ts` and `index.ts` from module-level singletons into proper classes, enabling multiple independent relay sessions to run in a single process on separate ports.

### Changes

**`cdp.ts` — `CDPSession` class**
- All module globals (`cdpWs`, `msgId`, `vpW/vpH`, `screenshotInterval`, etc.) moved to instance properties
- `cdpPort` is a constructor argument (default `9222`)
- All functions become instance methods: `connect`, `isConnected`, `handleAction`, `startScreenshots`, `stopScreenshots`, `setReconnectHandler`
- Log prefixes include `[cdp:<port>]` for easy multi-session log tailing

**`index.ts` — `RelaySession` class**
- All relay globals (`typeBuffer`, `queuedActions`, `reconnectTimer`, `streamViewers`, etc.) moved to instance properties
- Constructor accepts `{ port, cdpPort }`; `start()` creates Express app, HTTP server, and WebSocketServer
- Each instance owns its own reconnect loop and action queue
- Log prefixes include `[relay:<port>]`
- `/health` response now includes `cdpPort`

**Entry point — multi-port argv parsing**
```
# Single session (backward-compatible defaults)
node dist/index.js
PORT=7002 CDP_PORT=9223 node dist/index.js

# Multiple sessions — cdp port auto-derived (9222 + offset)
node dist/index.js 7001 7002 7003

# Explicit relay:cdp pairs
node dist/index.js 7001:9222 7002:9223
```

## Chrome launch (per session)
```bash
# Session 1
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
  --remote-debugging-port=9222 \
  --user-data-dir=/tmp/pplx-bridge-9222 \
  https://perplexity.ai

# Session 2
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
  --remote-debugging-port=9223 \
  --user-data-dir=/tmp/pplx-bridge-9223 \
  https://perplexity.ai
```

Closes #70
Closes #78