### PR TITLE
feat(relay): add CDP_PORT env var for multi-session support

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -3,6 +3,8 @@
  */
 import { WebSocket } from 'ws';
 
+const CDP_PORT = Number(process.env.CDP_PORT ?? 9222);
+
 let cdpWs: WebSocket | null = null;
 let msgId = 1;
 let vpW = 1280;
@@ -36,8 +38,8 @@ function attachLifecycle(ws: WebSocket): void {
 
 export async function connectCDP(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
   _screenshotCallback = screenshotCallback;
-  const res = await fetch('http://localhost:9222/json');
-  if (!res.ok) throw new Error('[cdp] Chrome not reachable at localhost:9222');
+  const res = await fetch(`http://localhost:${CDP_PORT}/json`);
+  if (!res.ok) throw new Error(`[cdp] Chrome not reachable at localhost:${CDP_PORT}`);
   const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
   const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
              ?? targets.find(t => t.type === 'page');

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -9,6 +9,7 @@ import { connectCDP, handleAction, startScreenshots, stopScreenshots, isCDPConne
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = Number(process.env.PORT ?? 7001);
+const CDP_PORT = Number(process.env.CDP_PORT ?? 9222);
 const SCREENSHOT_FPS = 5;
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
@@ -47,7 +48,7 @@ app.get('/assets/*', async (req, res) => {
   }
 });
 
-app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdp: isCDPConnected() }));
+app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, cdpPort: CDP_PORT, cdp: isCDPConnected() }));
 
 const wss = new WebSocketServer({ server });
 const streamViewers = new Set<WebSocket>();
@@ -259,7 +260,7 @@ server.listen(PORT, async () => {
   console.log(`  Health       http://localhost:${PORT}/health\n`);
   console.log(`  ⚠️  Start Chrome with:`);
   console.log(`     /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\`);
-  console.log(`       --remote-debugging-port=9222 \\`);
+  console.log(`       --remote-debugging-port=${CDP_PORT} \\`);
   console.log(`       --user-data-dir=/tmp/pplx-bridge-profile \\`);
   console.log(`       https://perplexity.ai\n`);
 
@@ -270,7 +271,7 @@ server.listen(PORT, async () => {
     console.log('[relay] CDP ready — input + screenshots active\n');
   } catch (err) {
     console.error('[relay] CDP connect failed:', (err as Error).message);
-    console.error('[relay] Start Chrome with --remote-debugging-port=9222 and restart relay\n');
+    console.error(`[relay] Start Chrome with --remote-debugging-port=${CDP_PORT} and restart relay\n`);
     scheduleReconnect();
   }
 });


### PR DESCRIPTION
Closes #79
Related #70

## What changed

- Added `CDP_PORT` env var (default `9222`) to `cdp.ts` — replaces hardcoded `localhost:9222`
- `index.ts` reads the same `CDP_PORT` constant for banner output and error messages
- `/health` endpoint now includes `cdpPort` in the response

## Files
- `packages/relay/src/cdp.ts`
- `packages/relay/src/index.ts`

## Usage — running two sessions

```bash
# Session 1
Google\ Chrome --remote-debugging-port=9222 --user-data-dir=/tmp/pplx-1 https://perplexity.ai &
PORT=7001 CDP_PORT=9222 node packages/relay/dist/index.js

# Session 2
Google\ Chrome --remote-debugging-port=9223 --user-data-dir=/tmp/pplx-2 https://perplexity.ai &
PORT=7002 CDP_PORT=9223 node packages/relay/dist/index.js
```

## Notes
Default remains `9222` — existing single-session usage is unchanged. Each relay process is fully isolated: its own reconnect loop, action queue, screenshot stream, and WebSocket channels.