### PR TITLE
docs: update README for multi-session UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Stream a live Chrome tab (`perplexity.ai`) as a continuous feed to a local relay
 
 ## 🏗️ Architecture
 
-The bridge operates by linking a debugging instance of Chrome to a local WebSocket relay, which then streams visual frames to the Comet viewer.
+The bridge operates by linking a debugging instance of Chrome to a local WebSocket relay, which then streams visual frames to the Comet viewer. Each `(PORT, CDP_PORT)` pair runs as an independent `RelaySession` within the same Node.js process.
 
 ```mermaid
 flowchart LR
     subgraph Browser ["🌐 Chrome Browser"]
-        CDP["CDP (Port 9222)<br/>--remote-debugging"]
+        CDP["CDP (default: 9222)<br/>--remote-debugging"]
     end
     
-    subgraph Relay ["⚡ Node.js Relay (localhost:7001)"]
+    subgraph Relay ["⚡ Node.js Relay (default: localhost:7001)"]
         WS["WebSocket Server"]
     end
     
@@ -123,7 +123,7 @@ In your **original terminal tab** (inside the `pplx-bridge` folder):
 ```bash
 pnpm start
 ```
-*When successful, the terminal will output:* `[relay] CDP ready — input + screenshots active`.
+*When successful, the terminal will output:* `[relay:7001] CDP ready — input + screenshots active`.
 
 Finally, open **Comet** and navigate to `http://localhost:7001/live`. You will see the live JPEG stream with a **● live** status indicator in the bottom right.
 
@@ -135,8 +135,10 @@ Finally, open **Comet** and navigate to `http://localhost:7001/live`. You will s
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| `PORT` | `7001` | Relay HTTP/WS port (7000 is reserved by macOS AirPlay) |
-| `PPLX_BRIDGE_CDP_PORT` | `9222` | Chrome remote debugging port |
+| `PORT` | `7001` | Relay HTTP/WS port (single session). Alias for `PORTS` with one entry. |
+| `CDP_PORT` | `9222` | Chrome remote debugging port (single session). Alias for `CDP_PORTS` with one entry. |
+| `PORTS` | `7001` | Comma-separated relay ports for multi-session, e.g. `7001,7002` |
+| `CDP_PORTS` | `9222` | Comma-separated Chrome debug ports for multi-session, e.g. `9222,9223`. Must have the same number of entries as `PORTS`. |
 
 ### NPM Scripts
 
@@ -144,6 +146,42 @@ Finally, open **Comet** and navigate to `http://localhost:7001/live`. You will s
 | :--- | :--- |
 | `pnpm build` | Compiles TypeScript for all workspace packages |
 | `pnpm start` | Builds packages and starts the relay |
+
+### Running multiple sessions
+
+<details>
+<summary><b>Multi-session setup (two Chrome instances, one relay process)</b></summary>
+<br/>
+
+Launch one Chrome instance per session, each with its own debugging port and user-data-dir:
+
+```bash
+# Session 1
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=~/.pplx-bridge-profile-1 \
+  https://perplexity.ai
+
+# Session 2 (new terminal tab)
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9223 \
+  --user-data-dir=~/.pplx-bridge-profile-2 \
+  https://perplexity.ai
+```
+
+Then start the relay with both port pairs:
+
+```bash
+PORTS=7001,7002 CDP_PORTS=9222,9223 pnpm start
+```
+
+Each session runs fully independently — its own WebSocket endpoints, action queue, screenshot stream, and reconnect loop. Open each viewer in Comet:
+- `http://localhost:7001/live`
+- `http://localhost:7002/live`
+
+Health check per session: `GET http://localhost:700x/health` → `{ ok, port, cdpPort, cdp }`
+
+</details>
 
 ---
 
@@ -169,6 +207,10 @@ pplx-bridge/
 ├── packages/
 │   ├── extension/       # Chrome extension (action sender & frame pusher)
 │   ├── relay/           # Node.js WebSocket server & CDP client
+│   │   └── src/
+│   │       ├── main.ts          # Entry point — spawns one RelaySession per port pair
+│   │       ├── relay-session.ts # Per-session Express + WSS + reconnect logic
+│   │       └── cdp.ts           # CDPSession class — one per Chrome debug port
 │   └── viewer/          # Static live.html canvas viewer
 ├── ACTION_PROTOCOL.md   # Documentation for action payload format
 ├── package.json         # Workspace configuration
@@ -198,7 +240,7 @@ Comet does not have permission to interact with the local relay. Ensure <code>lo
 </details>
 
 <details>
-<summary><b>Error: <code>[relay] CDP connect failed</code></b></summary>
+<summary><b>Error: <code>[relay:7001] CDP connect failed</code></b></summary>
 <br/>
 Chrome is not running with the required debugging flags. Stop Chrome completely and relaunch it using the command provided in Stage 4.
 </details>
@@ -207,6 +249,12 @@ Chrome is not running with the required debugging flags. Stop Chrome completely 
 <summary><b>Error: <code>EADDRINUSE :::7001</code></b></summary>
 <br/>
 The port is already in use by another process. Run <code>lsof -ti :7001 | xargs kill -9</code> to free the port, then retry.
+</details>
+
+<details>
+<summary><b>Error: <code>PORTS and CDP_PORTS must have the same number of entries</code></b></summary>
+<br/>
+The number of relay ports and CDP ports must match exactly. Example: <code>PORTS=7001,7002 CDP_PORTS=9222,9223</code>.
 </details>
 
 <br/>


### PR DESCRIPTION
Closes #84
Closes #85
Closes #86
Closes #87

## What changed

- **Env var table** — fixed `PPLX_BRIDGE_CDP_PORT` → `CDP_PORT`; added `PORTS` and `CDP_PORTS` with descriptions
- **Stage 5 log** — updated expected output to `[relay:7001] CDP ready` (port-prefixed since #83)
- **Multi-session section** — added collapsible setup block under Configuration with two-Chrome launch + `PORTS=7001,7002 CDP_PORTS=9222,9223 pnpm start` example and health check shape
- **Architecture diagram** — changed hardcoded `Port 9222` / `localhost:7001` to `default: 9222` / `default: localhost:7001`; added note that each pair runs as an independent `RelaySession`
- **Project structure** — replaced `index.ts` with `main.ts`, `relay-session.ts`, `cdp.ts` with one-line descriptions
- **FAQ** — added entry for `PORTS and CDP_PORTS must have the same number of entries` error
- **CDP connect failed** error message updated to port-prefixed form `[relay:7001] CDP connect failed`

No other aspects of the README changed.