### PR TITLE
feat: multi-tab support via TARGET_URLS — single Chrome, multiple sessions (#91)

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -1,196 +1,219 @@
 /**
  * cdp.ts — direct Chrome DevTools Protocol client.
+ * All state is encapsulated in CDPSession so multiple instances can run in parallel.
  */
 import { WebSocket } from 'ws';
 
-let cdpWs: WebSocket | null = null;
-let msgId = 1;
-let vpW = 1280;
-let vpH = 800;
-let _screenshotCallback: ((jpeg: Buffer) => void) | null = null;
-let lastClickAt = 0;
-let _reconnectHandler: (() => void) | null = null;
-let _didSignalDisconnect = false;
+export class CDPSession {
+  readonly cdpPort: number;
+  readonly targetUrl: string | undefined;
 
-export function setCDPReconnectHandler(handler: () => void): void {
-  _reconnectHandler = handler;
-}
+  private cdpWs: WebSocket | null = null;
+  private msgId = 1;
+  private vpW = 1280;
+  private vpH = 800;
+  private screenshotCallback: ((jpeg: Buffer) => void) | null = null;
+  private lastClickAt = 0;
+  private reconnectHandler: (() => void) | null = null;
+  private didSignalDisconnect = false;
+  private screenshotInterval: ReturnType<typeof setInterval> | null = null;
 
-function signalDisconnect(): void {
-  if (_didSignalDisconnect) return;
-  _didSignalDisconnect = true;
-  cdpWs = null;
-  _reconnectHandler?.();
-}
+  constructor(cdpPort = 9222, targetUrl?: string) {
+    this.cdpPort = cdpPort;
+    this.targetUrl = targetUrl;
+  }
 
-function attachLifecycle(ws: WebSocket): void {
-  ws.on('close', () => {
-    console.log('[cdp] socket closed');
-    signalDisconnect();
-  });
-  ws.on('error', (err) => {
-    console.error('[cdp] socket error:', (err as Error).message);
-    signalDisconnect();
-  });
-}
+  setReconnectHandler(handler: () => void): void {
+    this.reconnectHandler = handler;
+  }
 
-export async function connectCDP(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
-  _screenshotCallback = screenshotCallback;
-  const res = await fetch('http://localhost:9222/json');
-  if (!res.ok) throw new Error('[cdp] Chrome not reachable at localhost:9222');
-  const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
-  const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
-             ?? targets.find(t => t.type === 'page');
-  if (!page) throw new Error('[cdp] No page target found.');
-  const ws = new WebSocket(page.webSocketDebuggerUrl);
-  await new Promise<void>((resolve, reject) => {
-    ws.once('open', resolve);
-    ws.once('error', reject);
-  });
-  cdpWs = ws;
-  _didSignalDisconnect = false;
-  attachLifecycle(ws);
-  await send('Page.enable', {});
-  await refreshViewport();
-  console.log(`[cdp] connected → ${page.url} (viewport ${vpW}x${vpH})`);
-}
+  private signalDisconnect(): void {
+    if (this.didSignalDisconnect) return;
+    this.didSignalDisconnect = true;
+    this.cdpWs = null;
+    this.reconnectHandler?.();
+  }
 
-export function isCDPConnected(): boolean {
-  return cdpWs?.readyState === WebSocket.OPEN;
-}
-
-function send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    if (!cdpWs || cdpWs.readyState !== WebSocket.OPEN) return reject(new Error('[cdp] not connected'));
-    const ws = cdpWs;
-    const id = msgId++;
-    const onMsg = (data: Buffer) => {
-      let msg: Record<string, unknown>;
-      try { msg = JSON.parse(data.toString()); } catch { return; }
-      if (msg.id !== id) return;
-      ws.off('message', onMsg);
-      if (msg.error) reject(msg.error); else resolve(msg.result);
-    };
-    ws.on('message', onMsg);
-    ws.send(JSON.stringify({ id, method, params }), (err) => {
-      if (!err) return;
-      ws.off('message', onMsg);
-      reject(err);
+  private attachLifecycle(ws: WebSocket): void {
+    ws.on('close', () => {
+      console.log(`[cdp:${this.cdpPort}] socket closed`);
+      this.signalDisconnect();
     });
-  });
-}
-
-async function refreshViewport(): Promise<void> {
-  try {
-    const layout = await send('Page.getLayoutMetrics') as Record<string, Record<string, number>>;
-    const vp = layout.cssVisualViewport ?? layout.cssLayoutViewport;
-    vpW = vp?.clientWidth  ?? 1280;
-    vpH = vp?.clientHeight ?? 800;
-  } catch { /* keep cached */ }
-}
-
-function coords(nx: number, ny: number) {
-  return { x: Math.round(nx * vpW), y: Math.round(ny * vpH) };
-}
-
-function keyCode(key: string): number {
-  const map: Record<string, number> = {
-    Enter: 13, Backspace: 8, Tab: 9, Escape: 27,
-    ArrowLeft: 37, ArrowUp: 38, ArrowRight: 39, ArrowDown: 40,
-    Delete: 46, Home: 36, End: 35,
-  };
-  return map[key] ?? 0;
-}
-
-export async function handleAction(action: Record<string, unknown>): Promise<void> {
-  const type = action.type as string;
-
-  if (type === 'mousemove') {
-    const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    return;
+    ws.on('error', (err) => {
+      console.error(`[cdp:${this.cdpPort}] socket error:`, (err as Error).message);
+      this.signalDisconnect();
+    });
   }
 
-  if (type === 'click') {
-    const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    await new Promise(r => setTimeout(r, 80));
-    await send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
-    await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
-    lastClickAt = Date.now();
-    setTimeout(() => refreshViewport(), 600);
-    console.log('[cdp] click at', x, y);
-    return;
+  async connect(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
+    this.screenshotCallback = screenshotCallback;
+    const res = await fetch(`http://localhost:${this.cdpPort}/json`);
+    if (!res.ok) throw new Error(`[cdp:${this.cdpPort}] Chrome not reachable at localhost:${this.cdpPort}`);
+    const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
+
+    let page: typeof targets[number] | undefined;
+    if (this.targetUrl) {
+      // Explicit URL pattern takes priority
+      page = targets.find(t => t.type === 'page' && t.url.includes(this.targetUrl!));
+      if (!page) throw new Error(`[cdp:${this.cdpPort}] No page target matching "${this.targetUrl}" found.`);
+    } else {
+      // Default: first perplexity.ai tab, then any page
+      page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
+          ?? targets.find(t => t.type === 'page');
+      if (!page) throw new Error(`[cdp:${this.cdpPort}] No page target found.`);
+    }
+
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+    this.cdpWs = ws;
+    this.didSignalDisconnect = false;
+    this.attachLifecycle(ws);
+    await this.send('Page.enable', {});
+    await this.refreshViewport();
+    console.log(`[cdp:${this.cdpPort}] connected → ${page.url} (viewport ${this.vpW}x${this.vpH})`);
   }
 
-  if (type === 'type') {
-    const sinceClick = Date.now() - lastClickAt;
-    if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
-    const text = action.value as string;
-    console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
-    const result = await send('Runtime.evaluate', {
-      expression: `(function() {
+  isConnected(): boolean {
+    return this.cdpWs?.readyState === WebSocket.OPEN;
+  }
+
+  private send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.cdpWs || this.cdpWs.readyState !== WebSocket.OPEN)
+        return reject(new Error(`[cdp:${this.cdpPort}] not connected`));
+      const ws = this.cdpWs;
+      const id = this.msgId++;
+      const onMsg = (data: Buffer) => {
+        let msg: Record<string, unknown>;
+        try { msg = JSON.parse(data.toString()); } catch { return; }
+        if (msg.id !== id) return;
+        ws.off('message', onMsg);
+        if (msg.error) reject(msg.error); else resolve(msg.result);
+      };
+      ws.on('message', onMsg);
+      ws.send(JSON.stringify({ id, method, params }), (err) => {
+        if (!err) return;
+        ws.off('message', onMsg);
+        reject(err);
+      });
+    });
+  }
+
+  private async refreshViewport(): Promise<void> {
+    try {
+      const layout = await this.send('Page.getLayoutMetrics') as Record<string, Record<string, number>>;
+      const vp = layout.cssVisualViewport ?? layout.cssLayoutViewport;
+      this.vpW = vp?.clientWidth  ?? 1280;
+      this.vpH = vp?.clientHeight ?? 800;
+    } catch { /* keep cached */ }
+  }
+
+  private coords(nx: number, ny: number) {
+    return { x: Math.round(nx * this.vpW), y: Math.round(ny * this.vpH) };
+  }
+
+  private keyCode(key: string): number {
+    const map: Record<string, number> = {
+      Enter: 13, Backspace: 8, Tab: 9, Escape: 27,
+      ArrowLeft: 37, ArrowUp: 38, ArrowRight: 39, ArrowDown: 40,
+      Delete: 46, Home: 36, End: 35,
+    };
+    return map[key] ?? 0;
+  }
+
+  async handleAction(action: Record<string, unknown>): Promise<void> {
+    const type = action.type as string;
+
+    if (type === 'mousemove') {
+      const { x, y } = this.coords(action.x as number, action.y as number);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+      return;
+    }
+
+    if (type === 'click') {
+      const { x, y } = this.coords(action.x as number, action.y as number);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+      await new Promise(r => setTimeout(r, 80));
+      await this.send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
+      this.lastClickAt = Date.now();
+      setTimeout(() => this.refreshViewport(), 600);
+      console.log(`[cdp:${this.cdpPort}] click at`, x, y);
+      return;
+    }
+
+    if (type === 'type') {
+      const sinceClick = Date.now() - this.lastClickAt;
+      if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
+      const text = action.value as string;
+      console.log(`[cdp:${this.cdpPort}] type:`, JSON.stringify(text.slice(0, 80)));
+      const result = await this.send('Runtime.evaluate', {
+        expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
   if (!el) el = document.activeElement;
   if (el) { el.focus(); }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;
 })()`,
-      returnByValue: true,
-      awaitPromise: false,
-    }) as { result: { value: unknown } };
-    console.log('[cdp] execCommand result:', result?.result?.value);
-    return;
-  }
-
-  if (type === 'keydown') {
-    const key = action.key as string;
-    if (['Meta', 'Shift', 'Control', 'Alt'].includes(key)) return;
-    const code      = (action.code as string) ?? key;
-    const shift     = Boolean(action.shiftKey);
-    const ctrl      = Boolean(action.ctrlKey);
-    const meta      = Boolean(action.metaKey);
-    const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
-    const vk        = keyCode(key);
-    const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
-    if (special.includes(key) || modifiers) {
-      if (key === 'Enter' && !modifiers) {
-        await send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });
-        await send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
-        await send('Input.dispatchKeyEvent', { type: 'keyUp',   key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
-      }
-      await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-      await send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-      console.log('[cdp] key:', key, modifiers ? `(modifiers:${modifiers})` : '');
+        returnByValue: true,
+        awaitPromise: false,
+      }) as { result: { value: unknown } };
+      console.log(`[cdp:${this.cdpPort}] execCommand result:`, result?.result?.value);
+      return;
     }
-    return;
+
+    if (type === 'keydown') {
+      const key = action.key as string;
+      if (['Meta', 'Shift', 'Control', 'Alt'].includes(key)) return;
+      const code      = (action.code as string) ?? key;
+      const shift     = Boolean(action.shiftKey);
+      const ctrl      = Boolean(action.ctrlKey);
+      const meta      = Boolean(action.metaKey);
+      const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
+      const vk        = this.keyCode(key);
+      const special   = ['Enter','Backspace','Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Delete','Home','End'];
+      if (special.includes(key) || modifiers) {
+        if (key === 'Enter' && !modifiers) {
+          await this.send('Input.dispatchKeyEvent', { type: 'keyDown', key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'char',    key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyUp',   key: ' ', text: ' ', unmodifiedText: ' ' });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+          await this.send('Input.dispatchKeyEvent', { type: 'keyUp',   key: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+        }
+        await this.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
+        await this.send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
+        console.log(`[cdp:${this.cdpPort}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
+      }
+      return;
+    }
+
+    if (type === 'scroll') {
+      const { x, y } = this.coords(0.5, 0.5);
+      await this.send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100 });
+      return;
+    }
   }
 
-  if (type === 'scroll') {
-    const { x, y } = coords(0.5, 0.5);
-    await send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100 });
-    return;
+  startScreenshots(fps = 1): void {
+    if (this.screenshotInterval) return;
+    let busy = false;
+    this.screenshotInterval = setInterval(async () => {
+      if (busy || !this.isConnected()) return;
+      busy = true;
+      try {
+        const result = await this.send('Page.captureScreenshot', { format: 'jpeg', quality: 60, fromSurface: true }) as { data: string };
+        if (this.screenshotCallback) this.screenshotCallback(Buffer.from(result.data, 'base64'));
+      } catch { /* ignore */ } finally { busy = false; }
+    }, Math.round(1000 / fps));
   }
-}
 
-let screenshotInterval = 0;
-
-export function startScreenshots(fps = 1): void {
-  if (screenshotInterval) return;
-  let busy = false;
-  screenshotInterval = setInterval(async () => {
-    if (busy || !isCDPConnected()) return;
-    busy = true;
-    try {
-      const result = await send('Page.captureScreenshot', { format: 'jpeg', quality: 60, fromSurface: true }) as { data: string };
-      if (_screenshotCallback) _screenshotCallback(Buffer.from(result.data, 'base64'));
-    } catch { /* ignore */ } finally { busy = false; }
-  }, Math.round(1000 / fps)) as unknown as number;
-}
-
-export function stopScreenshots(): void {
-  clearInterval(screenshotInterval);
-  screenshotInterval = 0;
+  stopScreenshots(): void {
+    if (this.screenshotInterval) {
+      clearInterval(this.screenshotInterval);
+      this.screenshotInterval = null;
+    }
+  }
 }

--- a/packages/relay/src/main.ts
+++ b/packages/relay/src/main.ts
@@ -1,0 +1,44 @@
+/**
+ * main.ts — entry point.
+ * Spawns one RelaySession per (port, cdpPort, targetUrl) triple.
+ *
+ * Single session (default, backward compatible):
+ *   node dist/main.js
+ *   PORT=7001 CDP_PORT=9222 node dist/main.js
+ *
+ * Multiple sessions on separate Chrome instances:
+ *   PORTS=7001,7002 CDP_PORTS=9222,9223 node dist/main.js
+ *
+ * Multiple sessions sharing one Chrome (multi-tab):
+ *   PORTS=7001,7002 CDP_PORTS=9222,9222 TARGET_URLS="perplexity.ai/search/foo,perplexity.ai/search/bar" node dist/main.js
+ */
+import { RelaySession } from './relay-session.js';
+
+function parseList(env: string | undefined, fallback: string): string[] {
+  return (env ?? fallback).split(',').map(s => s.trim());
+}
+
+const portStrs    = parseList(process.env.PORTS    ?? process.env.PORT,    '7001');
+const cdpPortStrs = parseList(process.env.CDP_PORTS ?? process.env.CDP_PORT, '9222');
+const targetUrls  = process.env.TARGET_URLS ? parseList(process.env.TARGET_URLS, '') : [];
+
+const ports    = portStrs.map(Number);
+const cdpPorts = cdpPortStrs.map(Number);
+
+if (ports.length !== cdpPorts.length) {
+  console.error('[main] PORTS and CDP_PORTS must have the same number of entries.');
+  console.error(`[main]   PORTS     = ${ports.join(', ')}`);
+  console.error(`[main]   CDP_PORTS = ${cdpPorts.join(', ')}`);
+  process.exit(1);
+}
+
+if (targetUrls.length > 0 && targetUrls.length !== ports.length) {
+  console.error('[main] TARGET_URLS must have the same number of entries as PORTS.');
+  console.error(`[main]   PORTS       = ${ports.join(', ')}`);
+  console.error(`[main]   TARGET_URLS = ${targetUrls.join(', ')}`);
+  process.exit(1);
+}
+
+for (let i = 0; i < ports.length; i++) {
+  new RelaySession(ports[i]!, cdpPorts[i]!, targetUrls[i]).start();
+}

--- a/packages/relay/src/relay-session.ts
+++ b/packages/relay/src/relay-session.ts
@@ -1,0 +1,281 @@
+import { execSync } from 'child_process';
+import express from 'express';
+import { createServer, ServerResponse } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { CDPSession } from './cdp.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.join(__dirname, 'public');
+
+const SCREENSHOT_FPS    = 5;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS  = 30_000;
+const QUEUED_ACTION_MAX = 20;
+const QUEUED_ACTION_TTL_MS = 10_000;
+
+type QueuedAction = {
+  action: Record<string, unknown>;
+  expiresAt: number;
+};
+
+export class RelaySession {
+  private cdp: CDPSession;
+  private streamViewers = new Set<WebSocket>();
+  private typeBuffer = '';
+  private typeTimer: ReturnType<typeof setTimeout> | null = null;
+  private queuedActions: QueuedAction[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelayMs = RECONNECT_BASE_MS;
+  private reconnectInFlight = false;
+
+  constructor(private port: number, private cdpPort: number, targetUrl?: string) {
+    this.cdp = new CDPSession(cdpPort, targetUrl);
+    // stopScreenshots is handled inside reconnectCDP; no need to call it in the handler too
+    this.cdp.setReconnectHandler(() => this.scheduleReconnect());
+  }
+
+  private broadcastFrame(jpeg: Buffer): void {
+    const data = jpeg.buffer.slice(jpeg.byteOffset, jpeg.byteOffset + jpeg.byteLength);
+    for (const v of this.streamViewers) {
+      if (v.readyState === WebSocket.OPEN) v.send(data, { binary: true });
+    }
+  }
+
+  private flushTypeBuffer(): string {
+    if (!this.typeBuffer) return '';
+    const text = this.typeBuffer;
+    this.typeBuffer = '';
+    if (this.typeTimer) {
+      clearTimeout(this.typeTimer);
+      this.typeTimer = null;
+    }
+    console.log(`[relay:${this.port}] flush type:`, JSON.stringify(text.slice(0, 80)));
+    return text;
+  }
+
+  private handlePaste(): void {
+    try {
+      const text = execSync('pbpaste', { encoding: 'utf8' }).trim();
+      if (!text) { console.log(`[relay:${this.port}] paste: clipboard empty`); return; }
+      console.log(`[relay:${this.port}] paste:`, JSON.stringify(text.slice(0, 80)));
+      this.enqueueOrRunAction({ type: 'type', value: text });
+    } catch (err) {
+      console.error(`[relay:${this.port}] pbpaste failed:`, (err as Error).message);
+    }
+  }
+
+  private pruneQueuedActions(): void {
+    const now = Date.now();
+    while (this.queuedActions.length && this.queuedActions[0]!.expiresAt <= now) this.queuedActions.shift();
+  }
+
+  private queueAction(action: Record<string, unknown>): void {
+    this.pruneQueuedActions();
+    if (this.queuedActions.length >= QUEUED_ACTION_MAX) this.queuedActions.shift();
+    this.queuedActions.push({ action, expiresAt: Date.now() + QUEUED_ACTION_TTL_MS });
+    console.log(`[relay:${this.port}] queued action while disconnected:`, JSON.stringify(action).slice(0, 120));
+  }
+
+  private async runAction(action: Record<string, unknown>): Promise<void> {
+    try {
+      await this.cdp.handleAction(action);
+    } catch (err) {
+      if ((err as Error).message?.includes('not connected')) {
+        this.queueAction(action);
+        this.scheduleReconnect();
+        return;
+      }
+      console.error(`[relay:${this.port}] CDP action error:`, (err as Error).message ?? err);
+    }
+  }
+
+  private enqueueOrRunAction(action: Record<string, unknown>): void {
+    if (!this.cdp.isConnected()) {
+      this.queueAction(action);
+      this.scheduleReconnect();
+      return;
+    }
+    this.runAction(action).catch((err) => {
+      console.error(`[relay:${this.port}] action pipeline error:`, (err as Error).message ?? err);
+    });
+  }
+
+  private async flushQueuedActions(): Promise<void> {
+    this.pruneQueuedActions();
+    while (this.queuedActions.length && this.cdp.isConnected()) {
+      const next = this.queuedActions.shift();
+      if (!next || next.expiresAt <= Date.now()) continue;
+      await this.runAction(next.action);
+    }
+  }
+
+  private async reconnectCDP(): Promise<void> {
+    if (this.reconnectInFlight || this.cdp.isConnected()) return;
+    this.reconnectInFlight = true;
+    this.cdp.stopScreenshots();
+    try {
+      console.log(`[relay:${this.port}] reconnecting CDP...`);
+      await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+      this.cdp.startScreenshots(SCREENSHOT_FPS);
+      console.log(`[relay:${this.port}] CDP reconnected`);
+      await this.flushQueuedActions();
+      // Reset backoff only after flush succeeds — so a bad-flush loop stays throttled
+      this.reconnectDelayMs = RECONNECT_BASE_MS;
+    } catch (err) {
+      console.error(`[relay:${this.port}] reconnect failed:`, (err as Error).message);
+      this.scheduleReconnect();
+    } finally {
+      this.reconnectInFlight = false;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.cdp.isConnected() || this.reconnectTimer || this.reconnectInFlight) return;
+    const delay = this.reconnectDelayMs;
+    console.log(`[relay:${this.port}] scheduling reconnect in ${delay}ms`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectCDP().catch((err) => {
+        console.error(`[relay:${this.port}] reconnect pipeline error:`, (err as Error).message ?? err);
+      });
+    }, delay);
+    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, RECONNECT_MAX_MS);
+  }
+
+  start(): void {
+    const app    = express();
+    const server = createServer(app);
+    const wss    = new WebSocketServer({ server });
+
+    app.use((_req, res: ServerResponse & { setHeader: (k: string, v: string) => void }, next) => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      next();
+    });
+
+    app.use(express.static(publicDir));
+    app.get('/live', (_req, res) => res.sendFile(path.join(publicDir, 'live.html')));
+
+    app.get('/assets/*', async (req, res) => {
+      const raw    = (req.params as Record<string, string>)[0];
+      const target = decodeURIComponent(raw);
+      if (!target.startsWith('https://')) { res.status(400).send('only https:// targets allowed'); return; }
+      try {
+        const upstream = await fetch(target, { headers: { 'User-Agent': 'pplx-bridge/0.1 asset-proxy' } });
+        const ct = upstream.headers.get('content-type');
+        if (ct) res.setHeader('content-type', ct);
+        res.removeHeader('content-security-policy');
+        res.removeHeader('x-frame-options');
+        res.removeHeader('cross-origin-resource-policy');
+        res.send(Buffer.from(await upstream.arrayBuffer()));
+      } catch (err) {
+        console.error(`[relay:${this.port}] asset proxy error:`, err);
+        res.status(502).send('proxy error');
+      }
+    });
+
+    app.get('/health', (_req, res) => res.json({
+      ok: true,
+      port: this.port,
+      cdpPort: this.cdpPort,
+      targetUrl: this.cdp.targetUrl ?? null,
+      cdp: this.cdp.isConnected(),
+    }));
+
+    wss.on('connection', (ws, req) => {
+      const url = req.url ?? '';
+
+      if (url === '/stream/push') {
+        console.log(`[relay:${this.port}] ▲ streamer connected (CDP mode ignores this)`);
+        ws.on('message', () => {});
+        ws.on('close', () => console.log(`[relay:${this.port}] ▼ streamer disconnected`));
+
+      } else if (url === '/stream') {
+        this.streamViewers.add(ws);
+        console.log(`[relay:${this.port}] ▲ stream-viewer connected (total: ${this.streamViewers.size})`);
+        ws.on('close', () => {
+          this.streamViewers.delete(ws);
+          console.log(`[relay:${this.port}] ▼ stream-viewer disconnected`);
+        });
+
+      } else if (url === '/actions') {
+        let isReceiver = false;
+
+        ws.on('message', (raw) => {
+          let parsed: Record<string, unknown> | null = null;
+          try { parsed = JSON.parse(raw instanceof Buffer ? raw.toString() : String(raw)); } catch (_) {}
+
+          if (parsed?.register === 'extension') {
+            isReceiver = true;
+            console.log(`[relay:${this.port}] ▲ action-receiver (ext) connected — CDP mode: extension ignored for input`);
+            return;
+          }
+
+          if (!isReceiver) {
+            if (!parsed) return;
+
+            if (
+              parsed.type === 'keydown' &&
+              parsed.key === 'v' &&
+              parsed.metaKey === true
+            ) {
+              const buffered = this.flushTypeBuffer();
+              if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+              console.log(`[relay:${this.port}] action → Cmd+V (intercepted as paste)`);
+              this.handlePaste();
+              return;
+            }
+
+            if (parsed.type === 'type' && typeof parsed.value === 'string' && parsed.value.length === 1) {
+              this.typeBuffer += parsed.value as string;
+              if (this.typeTimer) clearTimeout(this.typeTimer);
+              this.typeTimer = setTimeout(() => {
+                const buffered = this.flushTypeBuffer();
+                if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+              }, 200);
+              return;
+            }
+
+            const buffered = this.flushTypeBuffer();
+            if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+
+            if (parsed.type !== 'mousemove') {
+              console.log(`[relay:${this.port}] action →`, JSON.stringify(parsed).slice(0, 120));
+            }
+            this.enqueueOrRunAction(parsed);
+          }
+        });
+
+        ws.on('close', () => {
+          if (isReceiver) console.log(`[relay:${this.port}] ▼ action-receiver (ext) disconnected`);
+        });
+      }
+    });
+
+    server.listen(this.port, async () => {
+      const w = 44;
+      console.log(`\n╔${'═'.repeat(w)}╗`);
+      console.log(`║  pplx-bridge relay  →  localhost:${this.port}${' '.repeat(w - 28 - String(this.port).length)}║`);
+      console.log(`╚${'═'.repeat(w)}╝`);
+      console.log(`  Stream view  ws://localhost:${this.port}/stream`);
+      console.log(`  Actions      ws://localhost:${this.port}/actions`);
+      console.log(`  Viewer       http://localhost:${this.port}/live`);
+      console.log(`  Health       http://localhost:${this.port}/health\n`);
+      console.log(`  ⚠️  Chrome must be started with --remote-debugging-port=${this.cdpPort}`);
+      if (this.cdp.targetUrl) console.log(`  🎯  Targeting tab matching: "${this.cdp.targetUrl}"`);
+      console.log();
+
+      try {
+        await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+        this.reconnectDelayMs = RECONNECT_BASE_MS;
+        this.cdp.startScreenshots(SCREENSHOT_FPS);
+        console.log(`[relay:${this.port}] CDP ready — input + screenshots active\n`);
+      } catch (err) {
+        console.error(`[relay:${this.port}] CDP connect failed:`, (err as Error).message);
+        this.scheduleReconnect();
+      }
+    });
+  }
+}


### PR DESCRIPTION
Closes #91

## Problem

The multi-session setup from #83 requires one Chrome instance per session. In practice one Chrome uses 500MB+ RAM, making two instances impractical.

Root cause: `CDPSession.connect()` always picks the **first matching tab** from the CDP `/json` list, so two sessions on the same port always land on the same tab.

## Solution

Add an optional `targetUrl` string parameter to `CDPSession` (and `RelaySession`). When provided, `connect()` picks the first tab whose URL includes `targetUrl`. When omitted, behaviour is unchanged.

A new `TARGET_URLS` env var in `main.ts` wires this up per session.

## Usage

**Single session — unchanged:**
```sh
pnpm start
```

**Two tabs in one Chrome:**
```sh
# One Chrome, two Perplexity tabs open
PORTS=7001,7002 CDP_PORTS=9222,9222 TARGET_URLS="perplexity.ai/search/foo,perplexity.ai/search/bar" pnpm start
```

Each viewer is fully independent:
- `http://localhost:7001/live` → tab matching `perplexity.ai/search/foo`
- `http://localhost:7002/live` → tab matching `perplexity.ai/search/bar`

**Health check** now includes `targetUrl`:
```json
{ "ok": true, "port": 7001, "cdpPort": 9222, "targetUrl": "perplexity.ai/search/foo", "cdp": true }
```

## Files changed

| File | Change |
|---|---|
| `packages/relay/src/cdp.ts` | `CDPSession` constructor accepts optional `targetUrl`; `connect()` uses it for tab selection; `targetUrl` exposed as `readonly` |
| `packages/relay/src/relay-session.ts` | Constructor forwards `targetUrl` to `CDPSession`; `/health` includes `targetUrl`; startup log prints target when set |
| `packages/relay/src/main.ts` | Parses `TARGET_URLS` env var; validates count matches `PORTS`; passes per-session value to `RelaySession` |

## Notes

- `TARGET_URLS` is entirely optional — omitting it keeps existing behaviour
- When `TARGET_URLS` entries are identical (e.g. both `perplexity.ai`), both sessions will match the same tab — use distinct URL patterns to differentiate tabs
- This PR is based on `main` and includes all changes from #83