### PR TITLE
feat: multi-tab single-Chrome support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Open a **new terminal tab** and launch an isolated Chrome profile:
   --user-data-dir=~/.pplx-bridge-profile \
   https://perplexity.ai
 ```
-*(Note: You will need to log into Perplexity on the first run. The custom `--user-data-dir` ensures your session persists across reboots.)*
+*(Note: You will need to log into Perplexity on the first run. The custom `--user-data-dir` ensures your session persists across reboots. For multi-session, open additional `perplexity.ai` tabs in the same Chrome window.)*
 
 ### Stage 5: Start the Relay & Connect
 In your **original terminal tab** (inside the `pplx-bridge` folder):
@@ -136,9 +136,9 @@ Finally, open **Comet** and navigate to `http://localhost:7001/live`. You will s
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | `PORT` | `7001` | Relay HTTP/WS port (single session). Alias for `PORTS` with one entry. |
-| `CDP_PORT` | `9222` | Chrome remote debugging port (single session). Alias for `CDP_PORTS` with one entry. |
-| `PORTS` | `7001` | Comma-separated relay ports for multi-session, e.g. `7001,7002` |
-| `CDP_PORTS` | `9222` | Comma-separated Chrome debug ports for multi-session, e.g. `9222,9223`. Must have the same number of entries as `PORTS`. |
+| `CDP_PORT` | `9222` | Chrome remote debugging port. Used for single-session and multi-tab mode. |
+| `PORTS` | `7001` | Comma-separated relay ports, e.g. `7001,7002` |
+| `CDP_PORTS` | — | *(Legacy)* Comma-separated Chrome debug ports for separate-Chrome-per-session mode, e.g. `9222,9223`. Must match `PORTS` length. Omit when using multi-tab mode. |
 
 ### NPM Scripts
 
@@ -150,7 +150,34 @@ Finally, open **Comet** and navigate to `http://localhost:7001/live`. You will s
 ### Running multiple sessions
 
 <details>
-<summary><b>Multi-session setup (two Chrome instances, one relay process)</b></summary>
+<summary><b>Multi-tab mode — one Chrome, multiple tabs (recommended)</b></summary>
+<br/>
+
+Open two or more `perplexity.ai` tabs in your already-running debug Chrome instance, then start the relay with `PORTS` and a single `CDP_PORT`:
+
+```bash
+PORTS=7001,7002 CDP_PORT=9222 pnpm start
+```
+
+The relay auto-discovers open `perplexity.ai` tabs and pins each session to a specific tab by CDP target ID. Each session reconnects to its own tab even after a relay restart.
+
+You will see:
+```
+[main] Multi-tab mode — 2 sessions on CDP port 9222
+[main]   :7001 → target ABC123 (https://www.perplexity.ai/...)
+[main]   :7002 → target DEF456 (https://www.perplexity.ai/...)
+```
+
+Open each viewer in Comet:
+- `http://localhost:7001/live`
+- `http://localhost:7002/live`
+
+Health check per session: `GET http://localhost:700x/health` → `{ ok, port, cdpPort, targetId, targetUrl, cdp }`
+
+</details>
+
+<details>
+<summary><b>Legacy mode — separate Chrome instance per session</b></summary>
 <br/>
 
 Launch one Chrome instance per session, each with its own debugging port and user-data-dir:
@@ -175,11 +202,7 @@ Then start the relay with both port pairs:
 PORTS=7001,7002 CDP_PORTS=9222,9223 pnpm start
 ```
 
-Each session runs fully independently — its own WebSocket endpoints, action queue, screenshot stream, and reconnect loop. Open each viewer in Comet:
-- `http://localhost:7001/live`
-- `http://localhost:7002/live`
-
-Health check per session: `GET http://localhost:700x/health` → `{ ok, port, cdpPort, cdp }`
+Each session runs fully independently — its own WebSocket endpoints, action queue, screenshot stream, and reconnect loop.
 
 </details>
 
@@ -210,7 +233,7 @@ pplx-bridge/
 │   │   └── src/
 │   │       ├── main.ts          # Entry point — spawns one RelaySession per port pair
 │   │       ├── relay-session.ts # Per-session Express + WSS + reconnect logic
-│   │       └── cdp.ts           # CDPSession class — one per Chrome debug port
+│   │       └── cdp.ts           # CDPSession class — multiple sessions may share one Chrome debug port
 │   └── viewer/          # Static live.html canvas viewer
 ├── ACTION_PROTOCOL.md   # Documentation for action payload format
 ├── package.json         # Workspace configuration
@@ -252,9 +275,15 @@ The port is already in use by another process. Run <code>lsof -ti :7001 | xargs 
 </details>
 
 <details>
+<summary><b>Error: <code>Not enough perplexity.ai tabs open</code></b></summary>
+<br/>
+In multi-tab mode, the relay needs one open <code>perplexity.ai</code> tab per requested session. Open the required number of tabs in your debug Chrome instance and run <code>pnpm start</code> again.
+</details>
+
+<details>
 <summary><b>Error: <code>PORTS and CDP_PORTS must have the same number of entries</code></b></summary>
 <br/>
-The number of relay ports and CDP ports must match exactly. Example: <code>PORTS=7001,7002 CDP_PORTS=9222,9223</code>.
+<em>(Legacy multi-Chrome mode only.)</em> The number of relay ports and CDP ports must match exactly. Example: <code>PORTS=7001,7002 CDP_PORTS=9222,9223</code>. For single-Chrome multi-tab mode, use <code>CDP_PORT</code> (singular) instead.
 </details>
 
 <br/>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "build":  "pnpm -r build",
     "dev":    "pnpm -r --parallel dev",
     "check":  "bash scripts/check-prereqs.sh",
-    "start":  "pnpm build && node packages/relay/dist/index.js",
-    "relay":  "node packages/relay/dist/index.js",
+    "start":  "pnpm build && node packages/relay/dist/main.js",
+    "relay":  "node packages/relay/dist/main.js",
     "chrome": "bash scripts/launch-chrome.sh"
   },
   "devDependencies": {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,19 +1,20 @@
 // src/background.ts — service worker
-// Extension no longer owns CDP or frame capture.
-// The relay owns the CDP session and streams frames via Page.startScreencast.
-// Extension responsibility: manage offscreen document for WebSocket relay bridge.
+// Extension no longer owns CDP. The relay owns the CDP session for each tab.
+// Extension responsibility: create the offscreen document so it can maintain
+// persistent WebSocket connections to the relay. Frame capture is handled
+// entirely by the relay via Page.startScreencast — captureVisibleTab must NOT
+// be used here because it activates the captured tab, firing focus/visibility
+// events that reset Lexical's caret position in background tabs.
 
-let capturing    = false;
+let offscreenReady = false;
 let captureTabId: number | null = null;
 
 // ── Main click handler ────────────────────────────────────────────────────────
 chrome.action.onClicked.addListener(async (tab) => {
-  if (capturing) { stopCapture(); return; }
   if (!tab.id) return;
   const tabId = tab.id;
   captureTabId = tabId;
-  capturing = true;
-  console.log('[bg] starting capture for tab', tabId);
+  console.log('[bg] activating relay bridge for tab', tabId);
 
   // Create offscreen document — owns WebSocket connections persistently
   try {
@@ -25,6 +26,7 @@ chrome.action.onClicked.addListener(async (tab) => {
         justification: 'Persistent WebSocket relay bridge for pplx-bridge',
       });
       console.log('[bg] offscreen document created');
+      offscreenReady = true;
     }
   } catch (err) {
     console.error('[bg] offscreen create failed:', err);
@@ -43,10 +45,3 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
 });
-
-function stopCapture() {
-  capturing    = false;
-  captureTabId = null;
-  (chrome.offscreen as any).closeDocument?.().catch(() => {});
-  console.log('[bg] capture stopped');
-}

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,134 +1,27 @@
 // src/background.ts — service worker
-const FPS     = 1;
-const QUALITY = 60; // 0-100 for Page.captureScreenshot
+// Extension no longer owns CDP. The relay owns the CDP session for each tab.
+// Extension responsibility: capture frames via chrome.tabs.captureVisibleTab and
+// push them to the relay via /stream/push. Actions flow relay → offscreen → (ignored,
+// relay dispatches input via CDP directly).
+
+const FPS     = 5;
+const QUALITY = 60;
 
 let capturing       = false;
 let intervalId      = 0;
 let capturing_frame = false;
-let debugTabId: number | null = null;
-
-// Cached viewport — refreshed once on attach, reused for every coord resolve
-let vpW = 1280;
-let vpH = 800;
-
-// ── CDP via chrome.debugger ───────────────────────────────────────────────────
-async function cdpAttach(tabId: number) {
-  await chrome.debugger.attach({ tabId }, '1.3');
-  debugTabId = tabId;
-  await cdpSend('Page.enable');
-  await refreshViewport();
-  console.log('[bg] debugger attached to tab', tabId, 'viewport', vpW, 'x', vpH);
-}
-
-async function cdpDetach() {
-  if (debugTabId === null) return;
-  try { await chrome.debugger.detach({ tabId: debugTabId }); } catch {}
-  debugTabId = null;
-}
-
-function cdpSend(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
-  if (debugTabId === null) return Promise.reject(new Error('debugger not attached'));
-  return chrome.debugger.sendCommand({ tabId: debugTabId }, method, params);
-}
-
-async function refreshViewport() {
-  try {
-    const layout = await cdpSend('Page.getLayoutMetrics') as Record<string, Record<string, number>>;
-    const vp = layout.cssVisualViewport ?? layout.cssLayoutViewport;
-    vpW = vp?.clientWidth  ?? 1280;
-    vpH = vp?.clientHeight ?? 800;
-  } catch { /* keep last known */ }
-}
-
-// Sync coord resolution — no async CDP call on every mouse event
-function resolveCoords(nx: number, ny: number): { x: number; y: number } {
-  return { x: Math.round(nx * vpW), y: Math.round(ny * vpH) };
-}
-
-// ── Action handler ────────────────────────────────────────────────────────────
-async function handleAction(action: Record<string, unknown>) {
-  const type = action.type as string;
-
-  if (type === 'mousemove') {
-    const { x, y } = resolveCoords(action.x as number, action.y as number);
-    await cdpSend('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    return;
-  }
-
-  if (type === 'click') {
-    const { x, y } = resolveCoords(action.x as number, action.y as number);
-    // Hover first (100ms) — React needs onMouseEnter/onMouseOver to fire before click
-    await cdpSend('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    await new Promise(r => setTimeout(r, 100));
-    await cdpSend('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
-    await cdpSend('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
-    // Refresh viewport cache after navigation that might result from click
-    setTimeout(() => refreshViewport(), 500);
-    console.log('[bg] CDP click at', x, y);
-    return;
-  }
-
-  if (type === 'type') {
-    const text = action.value as string;
-    await cdpSend('Input.insertText', { text });
-    return;
-  }
-
-  if (type === 'keydown') {
-    const key = action.key as string;
-    // Skip bare modifier-only keys — CDP rejects them
-    if (['Meta', 'Shift', 'Control', 'Alt'].includes(key)) return;
-    const code  = action.code as string;
-    const shift = (action.shiftKey as boolean) ?? false;
-    const ctrl  = (action.ctrlKey  as boolean) ?? false;
-    const meta  = (action.metaKey  as boolean) ?? false;
-    const modifiers = (ctrl ? 2 : 0) | (meta ? 4 : 0) | (shift ? 8 : 0);
-    await cdpSend('Input.dispatchKeyEvent', { type: 'keyDown', key, code, modifiers, windowsVirtualKeyCode: 0, nativeVirtualKeyCode: 0 });
-    await cdpSend('Input.dispatchKeyEvent', { type: 'keyUp',   key, code, modifiers, windowsVirtualKeyCode: 0, nativeVirtualKeyCode: 0 });
-    return;
-  }
-
-  if (type === 'scroll') {
-    const { x, y } = resolveCoords(0.5, 0.5);
-    const deltaX = (action.x as number) * 100;
-    const deltaY = (action.y as number) * 100;
-    await cdpSend('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX, deltaY });
-    return;
-  }
-}
-
-// ── Message listener: actions from offscreen ──────────────────────────────────
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  if (msg.type === 'action') {
-    let action: Record<string, unknown>;
-    try { action = JSON.parse(msg.payload as string); } catch { sendResponse({ ok: false }); return; }
-    if (action.type !== 'mousemove') console.log('[bg] action:', action.type, action);
-    handleAction(action)
-      .then(() => sendResponse({ ok: true }))
-      .catch((err) => { console.error('[bg] handleAction error:', err); sendResponse({ ok: false }); });
-    return true;
-  }
-});
+let captureTabId: number | null = null;
 
 // ── Main click handler ────────────────────────────────────────────────────────
 chrome.action.onClicked.addListener(async (tab) => {
   if (capturing) { stopCapture(); return; }
   if (!tab.id) return;
   const tabId = tab.id;
-
+  captureTabId = tabId;
   capturing = true;
   console.log('[bg] starting capture for tab', tabId);
 
-  // 1. Attach debugger (also enables Page domain + caches viewport)
-  try {
-    await cdpAttach(tabId);
-  } catch (err) {
-    console.error('[bg] debugger attach failed:', err);
-    stopCapture();
-    return;
-  }
-
-  // 2. Create offscreen document — owns WebSocket connections persistently
+  // Create offscreen document — owns WebSocket connections persistently
   try {
     const existing = await (chrome.offscreen as any).hasDocument?.();
     if (!existing) {
@@ -143,32 +36,40 @@ chrome.action.onClicked.addListener(async (tab) => {
     console.error('[bg] offscreen create failed:', err);
   }
 
-  // 3. Frame capture via CDP Page.captureScreenshot — same session as input, no race
+  // Send tabId to offscreen so it can resolve the correct relay port
+  try {
+    await chrome.runtime.sendMessage({ type: 'init', tabId });
+  } catch { /* offscreen may not be ready yet — it will request tabId on boot */ }
+
+  // Frame capture via captureVisibleTab — no CDP, no debugger ownership conflict
   intervalId = setInterval(async () => {
-    if (!capturing || capturing_frame) return;
+    if (!capturing || capturing_frame || captureTabId === null) return;
     capturing_frame = true;
     try {
-      const result = await cdpSend('Page.captureScreenshot', {
-        format: 'jpeg',
-        quality: QUALITY,
-        fromSurface: true,
-      }) as { data: string };
-      const dataUrl = `data:image/jpeg;base64,${result.data}`;
-      chrome.runtime.sendMessage({ type: 'frame', data: dataUrlToBuffer(dataUrl) })
-        .catch(() => {});
+      const dataUrl = await chrome.tabs.captureVisibleTab({ quality: QUALITY });
+      const buf = dataUrlToBuffer(dataUrl);
+      chrome.runtime.sendMessage({ type: 'frame', data: buf }).catch(() => {});
     } catch (err) {
-      console.warn('[bg] captureScreenshot error:', err);
+      console.warn('[bg] captureVisibleTab error:', (err as Error).message);
     } finally {
       capturing_frame = false;
     }
   }, Math.round(1000 / FPS)) as unknown as number;
 });
 
+// Respond to offscreen requesting tabId after it boots
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === 'getTabId') {
+    sendResponse({ tabId: captureTabId });
+    return true;
+  }
+});
+
 function stopCapture() {
   capturing       = false;
   capturing_frame = false;
+  captureTabId    = null;
   clearInterval(intervalId);
-  cdpDetach();
   (chrome.offscreen as any).closeDocument?.().catch(() => {});
   console.log('[bg] capture stopped');
 }

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,15 +1,9 @@
 // src/background.ts — service worker
-// Extension no longer owns CDP. The relay owns the CDP session for each tab.
-// Extension responsibility: capture frames via chrome.tabs.captureVisibleTab and
-// push them to the relay via /stream/push. Actions flow relay → offscreen → (ignored,
-// relay dispatches input via CDP directly).
+// Extension no longer owns CDP or frame capture.
+// The relay owns the CDP session and streams frames via Page.startScreencast.
+// Extension responsibility: manage offscreen document for WebSocket relay bridge.
 
-const FPS     = 5;
-const QUALITY = 60;
-
-let capturing       = false;
-let intervalId      = 0;
-let capturing_frame = false;
+let capturing    = false;
 let captureTabId: number | null = null;
 
 // ── Main click handler ────────────────────────────────────────────────────────
@@ -40,21 +34,6 @@ chrome.action.onClicked.addListener(async (tab) => {
   try {
     await chrome.runtime.sendMessage({ type: 'init', tabId });
   } catch { /* offscreen may not be ready yet — it will request tabId on boot */ }
-
-  // Frame capture via captureVisibleTab — no CDP, no debugger ownership conflict
-  intervalId = setInterval(async () => {
-    if (!capturing || capturing_frame || captureTabId === null) return;
-    capturing_frame = true;
-    try {
-      const dataUrl = await chrome.tabs.captureVisibleTab({ quality: QUALITY });
-      const buf = dataUrlToBuffer(dataUrl);
-      chrome.runtime.sendMessage({ type: 'frame', data: buf }).catch(() => {});
-    } catch (err) {
-      console.warn('[bg] captureVisibleTab error:', (err as Error).message);
-    } finally {
-      capturing_frame = false;
-    }
-  }, Math.round(1000 / FPS)) as unknown as number;
 });
 
 // Respond to offscreen requesting tabId after it boots
@@ -66,18 +45,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 });
 
 function stopCapture() {
-  capturing       = false;
-  capturing_frame = false;
-  captureTabId    = null;
-  clearInterval(intervalId);
+  capturing    = false;
+  captureTabId = null;
   (chrome.offscreen as any).closeDocument?.().catch(() => {});
   console.log('[bg] capture stopped');
-}
-
-function dataUrlToBuffer(dataUrl: string): ArrayBuffer {
-  const base64 = dataUrl.split(',')[1];
-  const binary = atob(base64);
-  const buf    = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) buf[i] = binary.charCodeAt(i);
-  return buf.buffer;
 }

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "pplx-bridge recorder",
-  "version": "0.4.2",
+  "version": "0.4.5",
   "description": "Streams perplexity.ai as JPEG frames to local relay. Part of pplx-bridge.",
   "permissions": ["tabs", "scripting", "storage", "debugger", "offscreen"],
   "host_permissions": [

--- a/packages/extension/src/offscreen.ts
+++ b/packages/extension/src/offscreen.ts
@@ -1,16 +1,71 @@
 // offscreen.ts — persistent WebSocket host
 // Offscreen documents are regular pages: Chrome does NOT apply the 30s SW kill timer.
-const RELAY = 'ws://localhost:7001';
+
+const PROBE_PORTS  = [7001, 7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009];
+const FALLBACK_PORT = 7001;
 
 let actWs:    WebSocket | null = null;
 let streamWs: WebSocket | null = null;
 
-// Actions WS: relay -> offscreen -> background SW -> CDP
-function connectActions() {
-  actWs = new WebSocket(`${RELAY}/actions`);
+// ── Port discovery via /health ────────────────────────────────────────────────
+
+interface HealthResponse {
+  port: number;
+  targetUrl?: string;
+  cdp: boolean;
+}
+
+async function probePort(port: number): Promise<HealthResponse | null> {
+  try {
+    const res = await fetch(`http://localhost:${port}/health`, { signal: AbortSignal.timeout(800) });
+    if (!res.ok) return null;
+    return await res.json() as HealthResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveRelayPort(): Promise<number> {
+  // Get the URL of the tab this offscreen doc was opened for
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabUrl = activeTab?.url ?? '';
+
+  const results = await Promise.all(PROBE_PORTS.map(p => probePort(p)));
+
+  // Exact URL match first
+  for (const health of results) {
+    if (health?.targetUrl && tabUrl && health.targetUrl === tabUrl) {
+      console.log(`[offscreen] matched relay port ${health.port} for ${tabUrl}`);
+      return health.port;
+    }
+  }
+
+  // Prefix match (handles query-string drift after navigation)
+  for (const health of results) {
+    if (health?.targetUrl && tabUrl && tabUrl.startsWith(health.targetUrl.split('?')[0])) {
+      console.log(`[offscreen] prefix-matched relay port ${health.port} for ${tabUrl}`);
+      return health.port;
+    }
+  }
+
+  // Fallback: first responding port
+  const first = results.find(h => h !== null);
+  if (first) {
+    console.warn(`[offscreen] no URL match — falling back to port ${first.port}`);
+    return first.port;
+  }
+
+  console.warn(`[offscreen] no relay found — falling back to port ${FALLBACK_PORT}`);
+  return FALLBACK_PORT;
+}
+
+// ── WebSocket connections ─────────────────────────────────────────────────────
+
+function connectActions(relay: string) {
+  actWs = new WebSocket(`${relay}/actions`);
   actWs.onopen = () => {
     actWs!.send(JSON.stringify({ register: 'extension' }));
-    console.log('[offscreen] actions WS connected');
+    console.log('[offscreen] actions WS connected to', relay);
   };
   actWs.onmessage = (msg) => {
     chrome.runtime.sendMessage({ type: 'action', payload: msg.data })
@@ -18,18 +73,17 @@ function connectActions() {
   };
   actWs.onclose = () => {
     console.warn('[offscreen] actions WS closed — reconnecting in 1s');
-    setTimeout(connectActions, 1000);
+    setTimeout(() => connectActions(relay), 1000);
   };
   actWs.onerror = () => console.error('[offscreen] actions WS error');
 }
 
-// Stream WS: background SW -> offscreen -> relay
-function connectStream() {
-  streamWs = new WebSocket(`${RELAY}/stream/push`);
-  streamWs.onopen  = () => console.log('[offscreen] stream WS connected');
+function connectStream(relay: string) {
+  streamWs = new WebSocket(`${relay}/stream/push`);
+  streamWs.onopen  = () => console.log('[offscreen] stream WS connected to', relay);
   streamWs.onclose = () => {
     console.warn('[offscreen] stream WS closed — reconnecting in 1s');
-    setTimeout(connectStream, 1000);
+    setTimeout(() => connectStream(relay), 1000);
   };
   streamWs.onerror = () => console.error('[offscreen] stream WS error');
 }
@@ -41,5 +95,11 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 });
 
-connectActions();
-connectStream();
+// ── Boot ──────────────────────────────────────────────────────────────────────
+
+(async () => {
+  const port  = await resolveRelayPort();
+  const relay = `ws://localhost:${port}`;
+  connectActions(relay);
+  connectStream(relay);
+})();

--- a/packages/extension/src/offscreen.ts
+++ b/packages/extension/src/offscreen.ts
@@ -1,11 +1,12 @@
 // offscreen.ts — persistent WebSocket host
 // Offscreen documents are regular pages: Chrome does NOT apply the 30s SW kill timer.
 
-const PROBE_PORTS  = [7001, 7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009];
+const PROBE_PORTS   = [7001, 7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009];
 const FALLBACK_PORT = 7001;
 
 let actWs:    WebSocket | null = null;
 let streamWs: WebSocket | null = null;
+let resolvedPort: number | null = null;
 
 // ── Port discovery via /health ────────────────────────────────────────────────
 
@@ -25,30 +26,48 @@ async function probePort(port: number): Promise<HealthResponse | null> {
   }
 }
 
-async function resolveRelayPort(): Promise<number> {
-  // Get the URL of the tab this offscreen doc was opened for
-  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const tabUrl = activeTab?.url ?? '';
+async function getTabUrl(tabId: number): Promise<string> {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ type: 'getTabId' }, (res) => {
+      // We already have tabId — just get the URL via chrome.tabs.get
+      chrome.tabs.get(tabId, (tab) => resolve(tab?.url ?? ''));
+    });
+  });
+}
 
-  const results = await Promise.all(PROBE_PORTS.map(p => probePort(p)));
+async function resolveRelayPort(tabId: number | null): Promise<number> {
+  const tabUrl = tabId ? await new Promise<string>((resolve) => {
+    chrome.tabs.get(tabId, (tab) => resolve(tab?.url ?? ''));
+  }) : '';
 
-  // Exact URL match first
-  for (const health of results) {
-    if (health?.targetUrl && tabUrl && health.targetUrl === tabUrl) {
-      console.log(`[offscreen] matched relay port ${health.port} for ${tabUrl}`);
-      return health.port;
+  // Retry until relay is up and URL matches (handles relay not yet connected at boot)
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const results = await Promise.all(PROBE_PORTS.map(p => probePort(p)));
+
+    // Exact URL match
+    for (const health of results) {
+      if (health?.targetUrl && tabUrl && health.targetUrl === tabUrl) {
+        console.log(`[offscreen] matched relay port ${health.port} for ${tabUrl}`);
+        return health.port;
+      }
     }
-  }
 
-  // Prefix match (handles query-string drift after navigation)
-  for (const health of results) {
-    if (health?.targetUrl && tabUrl && tabUrl.startsWith(health.targetUrl.split('?')[0])) {
-      console.log(`[offscreen] prefix-matched relay port ${health.port} for ${tabUrl}`);
-      return health.port;
+    // Prefix match (handles query-string drift)
+    for (const health of results) {
+      if (health?.targetUrl && tabUrl && tabUrl.startsWith(health.targetUrl.split('?')[0])) {
+        console.log(`[offscreen] prefix-matched relay port ${health.port} for ${tabUrl}`);
+        return health.port;
+      }
+    }
+
+    if (attempt < 9) {
+      console.log(`[offscreen] no URL match yet (attempt ${attempt + 1}/10) — retrying in 500ms`);
+      await new Promise(r => setTimeout(r, 500));
     }
   }
 
   // Fallback: first responding port
+  const results = await Promise.all(PROBE_PORTS.map(p => probePort(p)));
   const first = results.find(h => h !== null);
   if (first) {
     console.warn(`[offscreen] no URL match — falling back to port ${first.port}`);
@@ -68,8 +87,8 @@ function connectActions(relay: string) {
     console.log('[offscreen] actions WS connected to', relay);
   };
   actWs.onmessage = (msg) => {
-    chrome.runtime.sendMessage({ type: 'action', payload: msg.data })
-      .catch(() => {});
+    // Actions flow relay → CDP directly now; no need to forward to background
+    void msg;
   };
   actWs.onclose = () => {
     console.warn('[offscreen] actions WS closed — reconnecting in 1s');
@@ -97,9 +116,23 @@ chrome.runtime.onMessage.addListener((msg) => {
 
 // ── Boot ──────────────────────────────────────────────────────────────────────
 
-(async () => {
-  const port  = await resolveRelayPort();
+async function boot(tabId: number | null) {
+  const port  = await resolveRelayPort(tabId);
+  resolvedPort = port;
   const relay = `ws://localhost:${port}`;
   connectActions(relay);
   connectStream(relay);
+}
+
+// Listen for tabId from background (sent on extension icon click)
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'init' && typeof msg.tabId === 'number') {
+    if (resolvedPort === null) boot(msg.tabId as number);
+  }
+});
+
+// On first load, request tabId from background in case init message was missed
+(async () => {
+  const res = await chrome.runtime.sendMessage({ type: 'getTabId' }) as { tabId: number | null };
+  if (resolvedPort === null) boot(res?.tabId ?? null);
 })();

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -44,9 +44,12 @@ export class CDPSession {
   private lastClickAt = 0;
   private reconnectHandler: (() => void) | null = null;
   private didSignalDisconnect = false;
-  private screenshotInterval: ReturnType<typeof setInterval> | null = null;
+  private screencastActive = false;
   /** When set, reconnect will re-attach to this specific target ID. */
   private pinnedTargetId: string | undefined;
+
+  // Generic CDP event listeners: method → Set of handlers
+  private eventListeners = new Map<string, Set<(params: Record<string, unknown>) => void>>();
 
   constructor(cdpPort = 9222) {
     this.cdpPort = cdpPort;
@@ -59,11 +62,23 @@ export class CDPSession {
   private signalDisconnect(): void {
     if (this.didSignalDisconnect) return;
     this.didSignalDisconnect = true;
+    this.screencastActive = false;
     this.cdpWs = null;
     this.reconnectHandler?.();
   }
 
   private attachLifecycle(ws: WebSocket): void {
+    ws.on('message', (data: Buffer) => {
+      let msg: Record<string, unknown>;
+      try { msg = JSON.parse(data.toString()); } catch { return; }
+      // Route CDP events to registered listeners
+      if (typeof msg.method === 'string' && msg.params) {
+        const listeners = this.eventListeners.get(msg.method as string);
+        if (listeners) {
+          for (const fn of listeners) fn(msg.params as Record<string, unknown>);
+        }
+      }
+    });
     ws.on('close', () => {
       console.log(`[cdp:${this.cdpPort}/${this._targetId || '?'}] socket closed`);
       this.signalDisconnect();
@@ -72,6 +87,15 @@ export class CDPSession {
       console.error(`[cdp:${this.cdpPort}/${this._targetId || '?'}] socket error:`, (err as Error).message);
       this.signalDisconnect();
     });
+  }
+
+  private cdpOn(method: string, handler: (params: Record<string, unknown>) => void): void {
+    if (!this.eventListeners.has(method)) this.eventListeners.set(method, new Set());
+    this.eventListeners.get(method)!.add(handler);
+  }
+
+  private cdpOff(method: string, handler: (params: Record<string, unknown>) => void): void {
+    this.eventListeners.get(method)?.delete(handler);
   }
 
   /**
@@ -232,23 +256,56 @@ export class CDPSession {
     }
   }
 
-  startScreenshots(fps = 1): void {
-    if (this.screenshotInterval) return;
-    let busy = false;
-    this.screenshotInterval = setInterval(async () => {
-      if (busy || !this.isConnected()) return;
-      busy = true;
-      try {
-        const result = await this.send('Page.captureScreenshot', { format: 'jpeg', quality: 60, fromSurface: true }) as { data: string };
-        if (this.screenshotCallback) this.screenshotCallback(Buffer.from(result.data, 'base64'));
-      } catch { /* ignore */ } finally { busy = false; }
-    }, Math.round(1000 / fps));
+  // Screencast frame handler — kept as instance property so we can remove it on stop
+  private screencastFrameHandler: ((params: Record<string, unknown>) => void) | null = null;
+
+  /**
+   * Start streaming frames via Page.startScreencast.
+   * Replaces the old captureScreenshot polling — works correctly for
+   * background tabs because Chrome delivers screencast frames per-target
+   * regardless of which tab is focused.
+   *
+   * @param fps  Target frame rate (Chrome honours this only approximately).
+   */
+  startScreenshots(fps = 5): void {
+    if (this.screencastActive) return;
+    this.screencastActive = true;
+
+    this.screencastFrameHandler = (params) => {
+      const { data, sessionId } = params as { data: string; sessionId: number };
+      if (this.screenshotCallback) {
+        this.screenshotCallback(Buffer.from(data, 'base64'));
+      }
+      // Ack the frame so Chrome sends the next one
+      this.send('Page.screencastFrameAck', { sessionId }).catch(() => {});
+    };
+
+    this.cdpOn('Page.screencastFrame', this.screencastFrameHandler);
+
+    this.send('Page.startScreencast', {
+      format:        'jpeg',
+      quality:       60,
+      maxWidth:      this.vpW,
+      maxHeight:     this.vpH,
+      everyNthFrame: Math.max(1, Math.round(30 / fps)), // Chrome captures at ~30fps internally
+    }).catch((err) => {
+      console.error(`[cdp:${this.cdpPort}/${this._targetId}] startScreencast error:`, (err as Error).message);
+      this.screencastActive = false;
+    });
+
+    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screencast started (target ~${fps}fps)`);
   }
 
   stopScreenshots(): void {
-    if (this.screenshotInterval) {
-      clearInterval(this.screenshotInterval);
-      this.screenshotInterval = null;
+    if (!this.screencastActive) return;
+    this.screencastActive = false;
+
+    if (this.screencastFrameHandler) {
+      this.cdpOff('Page.screencastFrame', this.screencastFrameHandler);
+      this.screencastFrameHandler = null;
     }
+
+    this.send('Page.stopScreencast', {}).catch(() => {});
+    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screencast stopped`);
   }
 }

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -1,11 +1,37 @@
 /**
- * cdp.ts — direct Chrome DevTools Protocol client.
- * All state is encapsulated in CDPSession so multiple instances can run in parallel.
+ * cdp.ts — Chrome DevTools Protocol client, encapsulated as CDPSession.
+ * Instantiate one CDPSession per relay port / Chrome tab (target) pair.
+ * All sessions may share a single Chrome debug port.
  */
 import { WebSocket } from 'ws';
 
+export type CDPTarget = {
+  id: string;
+  type: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+};
+
+/** Fetch all page targets from a running Chrome instance. */
+export async function listTargets(cdpPort = 9222): Promise<CDPTarget[]> {
+  const res = await fetch(`http://localhost:${cdpPort}/json`);
+  if (!res.ok) throw new Error(`[cdp] Chrome not reachable at localhost:${cdpPort}`);
+  const all = await res.json() as Array<Record<string, string>>;
+  return all
+    .filter(t => t.type === 'page')
+    .map(t => ({
+      id: t.id ?? '',
+      type: t.type ?? '',
+      url: t.url ?? '',
+      webSocketDebuggerUrl: t.webSocketDebuggerUrl ?? '',
+    }));
+}
+
 export class CDPSession {
   readonly cdpPort: number;
+  /** Populated after connect() resolves. */
+  readonly targetId: string = '';
+  readonly targetUrl: string = '';
 
   private cdpWs: WebSocket | null = null;
   private msgId = 1;
@@ -16,6 +42,8 @@ export class CDPSession {
   private reconnectHandler: (() => void) | null = null;
   private didSignalDisconnect = false;
   private screenshotInterval: ReturnType<typeof setInterval> | null = null;
+  /** When set, reconnect will re-attach to this specific target ID. */
+  private pinnedTargetId: string | undefined;
 
   constructor(cdpPort = 9222) {
     this.cdpPort = cdpPort;
@@ -34,23 +62,37 @@ export class CDPSession {
 
   private attachLifecycle(ws: WebSocket): void {
     ws.on('close', () => {
-      console.log(`[cdp:${this.cdpPort}] socket closed`);
+      console.log(`[cdp:${this.cdpPort}/${this.targetId || '?'}] socket closed`);
       this.signalDisconnect();
     });
     ws.on('error', (err) => {
-      console.error(`[cdp:${this.cdpPort}] socket error:`, (err as Error).message);
+      console.error(`[cdp:${this.cdpPort}/${this.targetId || '?'}] socket error:`, (err as Error).message);
       this.signalDisconnect();
     });
   }
 
-  async connect(screenshotCallback: (jpeg: Buffer) => void): Promise<void> {
+  /**
+   * Connect to a Chrome tab.
+   * @param screenshotCallback  Called for each captured JPEG frame.
+   * @param targetId            Optional CDP target ID. If omitted, picks the
+   *                            first perplexity.ai page (or first page).
+   */
+  async connect(screenshotCallback: (jpeg: Buffer) => void, targetId?: string): Promise<void> {
     this.screenshotCallback = screenshotCallback;
-    const res = await fetch(`http://localhost:${this.cdpPort}/json`);
-    if (!res.ok) throw new Error(`[cdp:${this.cdpPort}] Chrome not reachable at localhost:${this.cdpPort}`);
-    const targets = await res.json() as Array<{ type: string; webSocketDebuggerUrl: string; url: string }>;
-    const page = targets.find(t => t.type === 'page' && t.url.includes('perplexity.ai'))
-               ?? targets.find(t => t.type === 'page');
-    if (!page) throw new Error(`[cdp:${this.cdpPort}] No page target found.`);
+    if (targetId) this.pinnedTargetId = targetId;
+
+    const targets = await listTargets(this.cdpPort);
+
+    let page: CDPTarget | undefined;
+    if (this.pinnedTargetId) {
+      page = targets.find(t => t.id === this.pinnedTargetId);
+      if (!page) throw new Error(`[cdp:${this.cdpPort}] target ${this.pinnedTargetId} not found`);
+    } else {
+      page = targets.find(t => t.url.includes('perplexity.ai')) ?? targets[0];
+      if (!page) throw new Error(`[cdp:${this.cdpPort}] No page target found.`);
+      this.pinnedTargetId = page.id;
+    }
+
     const ws = new WebSocket(page.webSocketDebuggerUrl);
     await new Promise<void>((resolve, reject) => {
       ws.once('open', resolve);
@@ -58,10 +100,13 @@ export class CDPSession {
     });
     this.cdpWs = ws;
     this.didSignalDisconnect = false;
+    // Store target metadata (readonly workaround via cast)
+    (this as { targetId: string }).targetId = page.id;
+    (this as { targetUrl: string }).targetUrl = page.url;
     this.attachLifecycle(ws);
     await this.send('Page.enable', {});
     await this.refreshViewport();
-    console.log(`[cdp:${this.cdpPort}] connected → ${page.url} (viewport ${this.vpW}x${this.vpH})`);
+    console.log(`[cdp:${this.cdpPort}/${page.id}] connected → ${page.url} (viewport ${this.vpW}x${this.vpH})`);
   }
 
   isConnected(): boolean {
@@ -129,7 +174,7 @@ export class CDPSession {
       await this.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
       this.lastClickAt = Date.now();
       setTimeout(() => this.refreshViewport(), 600);
-      console.log(`[cdp:${this.cdpPort}] click at`, x, y);
+      console.log(`[cdp:${this.cdpPort}/${this.targetId}] click at`, x, y);
       return;
     }
 
@@ -137,7 +182,7 @@ export class CDPSession {
       const sinceClick = Date.now() - this.lastClickAt;
       if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
       const text = action.value as string;
-      console.log(`[cdp:${this.cdpPort}] type:`, JSON.stringify(text.slice(0, 80)));
+      console.log(`[cdp:${this.cdpPort}/${this.targetId}] type:`, JSON.stringify(text.slice(0, 80)));
       const result = await this.send('Runtime.evaluate', {
         expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
@@ -149,7 +194,7 @@ export class CDPSession {
         returnByValue: true,
         awaitPromise: false,
       }) as { result: { value: unknown } };
-      console.log(`[cdp:${this.cdpPort}] execCommand result:`, result?.result?.value);
+      console.log(`[cdp:${this.cdpPort}/${this.targetId}] execCommand result:`, result?.result?.value);
       return;
     }
 
@@ -173,7 +218,7 @@ export class CDPSession {
         }
         await this.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
         await this.send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-        console.log(`[cdp:${this.cdpPort}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
+        console.log(`[cdp:${this.cdpPort}/${this.targetId}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
       }
       return;
     }

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -29,9 +29,12 @@ export async function listTargets(cdpPort = 9222): Promise<CDPTarget[]> {
 
 export class CDPSession {
   readonly cdpPort: number;
+
+  private _targetId  = '';
+  private _targetUrl = '';
   /** Populated after connect() resolves. */
-  readonly targetId: string = '';
-  readonly targetUrl: string = '';
+  get targetId()  { return this._targetId; }
+  get targetUrl() { return this._targetUrl; }
 
   private cdpWs: WebSocket | null = null;
   private msgId = 1;
@@ -62,11 +65,11 @@ export class CDPSession {
 
   private attachLifecycle(ws: WebSocket): void {
     ws.on('close', () => {
-      console.log(`[cdp:${this.cdpPort}/${this.targetId || '?'}] socket closed`);
+      console.log(`[cdp:${this.cdpPort}/${this._targetId || '?'}] socket closed`);
       this.signalDisconnect();
     });
     ws.on('error', (err) => {
-      console.error(`[cdp:${this.cdpPort}/${this.targetId || '?'}] socket error:`, (err as Error).message);
+      console.error(`[cdp:${this.cdpPort}/${this._targetId || '?'}] socket error:`, (err as Error).message);
       this.signalDisconnect();
     });
   }
@@ -100,9 +103,8 @@ export class CDPSession {
     });
     this.cdpWs = ws;
     this.didSignalDisconnect = false;
-    // Store target metadata (readonly workaround via cast)
-    (this as { targetId: string }).targetId = page.id;
-    (this as { targetUrl: string }).targetUrl = page.url;
+    this._targetId  = page.id;
+    this._targetUrl = page.url;
     this.attachLifecycle(ws);
     await this.send('Page.enable', {});
     await this.refreshViewport();
@@ -174,7 +176,7 @@ export class CDPSession {
       await this.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
       this.lastClickAt = Date.now();
       setTimeout(() => this.refreshViewport(), 600);
-      console.log(`[cdp:${this.cdpPort}/${this.targetId}] click at`, x, y);
+      console.log(`[cdp:${this.cdpPort}/${this._targetId}] click at`, x, y);
       return;
     }
 
@@ -182,7 +184,7 @@ export class CDPSession {
       const sinceClick = Date.now() - this.lastClickAt;
       if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
       const text = action.value as string;
-      console.log(`[cdp:${this.cdpPort}/${this.targetId}] type:`, JSON.stringify(text.slice(0, 80)));
+      console.log(`[cdp:${this.cdpPort}/${this._targetId}] type:`, JSON.stringify(text.slice(0, 80)));
       const result = await this.send('Runtime.evaluate', {
         expression: `(function() {
   var el = document.querySelector('[data-lexical-editor="true"]');
@@ -194,7 +196,7 @@ export class CDPSession {
         returnByValue: true,
         awaitPromise: false,
       }) as { result: { value: unknown } };
-      console.log(`[cdp:${this.cdpPort}/${this.targetId}] execCommand result:`, result?.result?.value);
+      console.log(`[cdp:${this.cdpPort}/${this._targetId}] execCommand result:`, result?.result?.value);
       return;
     }
 
@@ -218,7 +220,7 @@ export class CDPSession {
         }
         await this.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
         await this.send('Input.dispatchKeyEvent', { type: 'keyUp',      key, code, modifiers, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk });
-        console.log(`[cdp:${this.cdpPort}/${this.targetId}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
+        console.log(`[cdp:${this.cdpPort}/${this._targetId}] key:`, key, modifiers ? `(modifiers:${modifiers})` : '');
       }
       return;
     }

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -98,12 +98,6 @@ export class CDPSession {
     this.eventListeners.get(method)?.delete(handler);
   }
 
-  /**
-   * Connect to a Chrome tab.
-   * @param screenshotCallback  Called for each captured JPEG frame.
-   * @param targetId            Optional CDP target ID. If omitted, picks the
-   *                            first perplexity.ai page (or first page).
-   */
   async connect(screenshotCallback: (jpeg: Buffer) => void, targetId?: string): Promise<void> {
     this.screenshotCallback = screenshotCallback;
     if (targetId) this.pinnedTargetId = targetId;
@@ -211,9 +205,11 @@ export class CDPSession {
       console.log(`[cdp:${this.cdpPort}/${this._targetId}] type:`, JSON.stringify(text.slice(0, 80)));
       const result = await this.send('Runtime.evaluate', {
         expression: `(function() {
-  var el = document.querySelector('[data-lexical-editor="true"]');
-  if (!el) el = document.activeElement;
-  if (el) { el.focus(); }
+  var el = document.activeElement;
+  if (!el || el === document.body) {
+    el = document.querySelector('[data-lexical-editor="true"]');
+    if (el) el.focus();
+  }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;
 })()`,
@@ -256,17 +252,8 @@ export class CDPSession {
     }
   }
 
-  // Screencast frame handler — kept as instance property so we can remove it on stop
   private screencastFrameHandler: ((params: Record<string, unknown>) => void) | null = null;
 
-  /**
-   * Start streaming frames via Page.startScreencast.
-   * Replaces the old captureScreenshot polling — works correctly for
-   * background tabs because Chrome delivers screencast frames per-target
-   * regardless of which tab is focused.
-   *
-   * @param fps  Target frame rate (Chrome honours this only approximately).
-   */
   startScreenshots(fps = 5): void {
     if (this.screencastActive) return;
     this.screencastActive = true;
@@ -276,7 +263,6 @@ export class CDPSession {
       if (this.screenshotCallback) {
         this.screenshotCallback(Buffer.from(data, 'base64'));
       }
-      // Ack the frame so Chrome sends the next one
       this.send('Page.screencastFrameAck', { sessionId }).catch(() => {});
     };
 
@@ -287,7 +273,7 @@ export class CDPSession {
       quality:       60,
       maxWidth:      this.vpW,
       maxHeight:     this.vpH,
-      everyNthFrame: Math.max(1, Math.round(30 / fps)), // Chrome captures at ~30fps internally
+      everyNthFrame: Math.max(1, Math.round(30 / fps)),
     }).catch((err) => {
       console.error(`[cdp:${this.cdpPort}/${this._targetId}] startScreencast error:`, (err as Error).message);
       this.screencastActive = false;

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -44,7 +44,7 @@ export class CDPSession {
   private lastClickAt = 0;
   private reconnectHandler: (() => void) | null = null;
   private didSignalDisconnect = false;
-  private screencastActive = false;
+  private screenshotInterval: ReturnType<typeof setInterval> | null = null;
   /** When set, reconnect will re-attach to this specific target ID. */
   private pinnedTargetId: string | undefined;
 
@@ -62,7 +62,6 @@ export class CDPSession {
   private signalDisconnect(): void {
     if (this.didSignalDisconnect) return;
     this.didSignalDisconnect = true;
-    this.screencastActive = false;
     this.cdpWs = null;
     this.reconnectHandler?.();
   }
@@ -205,10 +204,9 @@ export class CDPSession {
       console.log(`[cdp:${this.cdpPort}/${this._targetId}] type:`, JSON.stringify(text.slice(0, 80)));
       const result = await this.send('Runtime.evaluate', {
         expression: `(function() {
-  var el = document.activeElement;
-  if (!el || el === document.body) {
-    el = document.querySelector('[data-lexical-editor="true"]');
-  }
+  var el = document.querySelector('[data-lexical-editor="true"]');
+  if (!el) el = document.activeElement;
+  if (el) { el.focus(); }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;
 })()`,
@@ -251,46 +249,28 @@ export class CDPSession {
     }
   }
 
-  private screencastFrameHandler: ((params: Record<string, unknown>) => void) | null = null;
-
   startScreenshots(fps = 5): void {
-    if (this.screencastActive) return;
-    this.screencastActive = true;
-
-    this.screencastFrameHandler = (params) => {
-      const { data, sessionId } = params as { data: string; sessionId: number };
-      if (this.screenshotCallback) {
-        this.screenshotCallback(Buffer.from(data, 'base64'));
-      }
-      this.send('Page.screencastFrameAck', { sessionId }).catch(() => {});
-    };
-
-    this.cdpOn('Page.screencastFrame', this.screencastFrameHandler);
-
-    this.send('Page.startScreencast', {
-      format:        'jpeg',
-      quality:       60,
-      maxWidth:      this.vpW,
-      maxHeight:     this.vpH,
-      everyNthFrame: Math.max(1, Math.round(30 / fps)),
-    }).catch((err) => {
-      console.error(`[cdp:${this.cdpPort}/${this._targetId}] startScreencast error:`, (err as Error).message);
-      this.screencastActive = false;
-    });
-
-    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screencast started (target ~${fps}fps)`);
+    if (this.screenshotInterval) return;
+    let busy = false;
+    this.screenshotInterval = setInterval(async () => {
+      if (busy || !this.isConnected()) return;
+      busy = true;
+      try {
+        const result = await this.send('Page.captureScreenshot', {
+          format: 'jpeg',
+          quality: 60,
+          fromSurface: true,
+        }) as { data: string };
+        if (this.screenshotCallback) this.screenshotCallback(Buffer.from(result.data, 'base64'));
+      } catch { /* ignore */ } finally { busy = false; }
+    }, Math.round(1000 / fps));
+    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screenshot polling started (~${fps}fps)`);
   }
 
   stopScreenshots(): void {
-    if (!this.screencastActive) return;
-    this.screencastActive = false;
-
-    if (this.screencastFrameHandler) {
-      this.cdpOff('Page.screencastFrame', this.screencastFrameHandler);
-      this.screencastFrameHandler = null;
-    }
-
-    this.send('Page.stopScreencast', {}).catch(() => {});
-    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screencast stopped`);
+    if (!this.screenshotInterval) return;
+    clearInterval(this.screenshotInterval);
+    this.screenshotInterval = null;
+    console.log(`[cdp:${this.cdpPort}/${this._targetId}] screenshot polling stopped`);
   }
 }

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -204,9 +204,6 @@ export class CDPSession {
       console.log(`[cdp:${this.cdpPort}/${this._targetId}] type:`, JSON.stringify(text.slice(0, 80)));
       const result = await this.send('Runtime.evaluate', {
         expression: `(function() {
-  var el = document.querySelector('[data-lexical-editor="true"]');
-  if (!el) el = document.activeElement;
-  if (el) { el.focus(); }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;
 })()`,

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -208,7 +208,6 @@ export class CDPSession {
   var el = document.activeElement;
   if (!el || el === document.body) {
     el = document.querySelector('[data-lexical-editor="true"]');
-    if (el) el.focus();
   }
   var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
   return ok;

--- a/packages/relay/src/main.ts
+++ b/packages/relay/src/main.ts
@@ -7,7 +7,7 @@
  *
  * Multi-tab (single Chrome, multiple perplexity.ai tabs):
  *   PORTS=7001,7002 CDP_PORT=9222 node dist/main.js
- *   → fetches all perplexity.ai tabs from CDP_PORT, assigns one per relay port
+ *   → waits until enough perplexity.ai tabs are open, then assigns one per relay port
  *
  * Multi-process fallback (separate Chrome per session, legacy):
  *   PORTS=7001,7002 CDP_PORTS=9222,9223 node dist/main.js
@@ -15,36 +15,42 @@
 import { RelaySession } from './relay-session.js';
 import { listTargets } from './cdp.js';
 
+const POLL_INTERVAL_MS = 2000;
+
 function parseList(env: string | undefined, fallback: string): number[] {
   return (env ?? fallback).split(',').map(s => Number(s.trim()));
 }
 
 const ports = parseList(process.env.PORTS ?? process.env.PORT, '7001');
 
-// Multi-tab mode: single CDP_PORT, enumerate tabs
+// Multi-tab mode: single CDP_PORT, wait until enough pplx tabs are open
 if (process.env.CDP_PORTS === undefined && ports.length > 1) {
   const cdpPort = Number(process.env.CDP_PORT ?? '9222');
 
   (async () => {
-    let targets;
-    try {
-      targets = await listTargets(cdpPort);
-    } catch (err) {
-      console.error('[main] Failed to reach Chrome:', (err as Error).message);
-      process.exit(1);
+    console.log(`[main] Multi-tab mode — waiting for ${ports.length} perplexity.ai tabs on CDP port ${cdpPort}...`);
+
+    // Poll until Chrome is reachable and has enough pplx tabs
+    let pplxTargets: Awaited<ReturnType<typeof listTargets>> = [];
+    let lastCount = -1;
+    while (pplxTargets.length < ports.length) {
+      try {
+        const all = await listTargets(cdpPort);
+        pplxTargets = all.filter(t => t.url.includes('perplexity.ai'));
+        if (pplxTargets.length !== lastCount) {
+          console.log(`[main]   Found ${pplxTargets.length}/${ports.length} perplexity.ai tab(s) — ${pplxTargets.length < ports.length ? `open ${ports.length - pplxTargets.length} more in Chrome...` : 'ready!'}`);
+          lastCount = pplxTargets.length;
+        }
+      } catch {
+        if (lastCount !== -2) {
+          console.log(`[main]   Chrome not reachable on port ${cdpPort} — start Chrome with --remote-debugging-port=${cdpPort}...`);
+          lastCount = -2;
+        }
+      }
+      if (pplxTargets.length < ports.length) await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
     }
 
-    const pplxTargets = targets.filter(t => t.url.includes('perplexity.ai'));
-
-    if (pplxTargets.length < ports.length) {
-      console.error(`[main] Not enough perplexity.ai tabs open.`);
-      console.error(`[main]   Requested sessions : ${ports.length}`);
-      console.error(`[main]   Open pplx tabs found: ${pplxTargets.length}`);
-      console.error(`[main]   Open ${ports.length} perplexity.ai tabs in Chrome (port ${cdpPort}) and retry.`);
-      process.exit(1);
-    }
-
-    console.log(`[main] Multi-tab mode — ${ports.length} sessions on CDP port ${cdpPort}`);
+    console.log(`[main] Starting ${ports.length} sessions on CDP port ${cdpPort}`);
     for (let i = 0; i < ports.length; i++) {
       const target = pplxTargets[i]!;
       console.log(`[main]   :${ports[i]} → target ${target.id} (${target.url})`);

--- a/packages/relay/src/main.ts
+++ b/packages/relay/src/main.ts
@@ -1,31 +1,69 @@
 /**
  * main.ts — entry point.
- * Spawns one RelaySession per (port, cdpPort) pair.
  *
  * Single session (default, backward compatible):
  *   node dist/main.js
  *   PORT=7001 CDP_PORT=9222 node dist/main.js
  *
- * Multiple sessions:
+ * Multi-tab (single Chrome, multiple perplexity.ai tabs):
+ *   PORTS=7001,7002 CDP_PORT=9222 node dist/main.js
+ *   → fetches all perplexity.ai tabs from CDP_PORT, assigns one per relay port
+ *
+ * Multi-process fallback (separate Chrome per session, legacy):
  *   PORTS=7001,7002 CDP_PORTS=9222,9223 node dist/main.js
  */
 import { RelaySession } from './relay-session.js';
+import { listTargets } from './cdp.js';
 
 function parseList(env: string | undefined, fallback: string): number[] {
   return (env ?? fallback).split(',').map(s => Number(s.trim()));
 }
 
-// Support both singular (PORT/CDP_PORT) and plural (PORTS/CDP_PORTS) env vars
-const ports    = parseList(process.env.PORTS    ?? process.env.PORT,    '7001');
-const cdpPorts = parseList(process.env.CDP_PORTS ?? process.env.CDP_PORT, '9222');
+const ports = parseList(process.env.PORTS ?? process.env.PORT, '7001');
 
-if (ports.length !== cdpPorts.length) {
-  console.error('[main] PORTS and CDP_PORTS must have the same number of entries.');
-  console.error(`[main]   PORTS     = ${ports.join(', ')}`);
-  console.error(`[main]   CDP_PORTS = ${cdpPorts.join(', ')}`);
-  process.exit(1);
-}
+// Multi-tab mode: single CDP_PORT, enumerate tabs
+if (process.env.CDP_PORTS === undefined && ports.length > 1) {
+  const cdpPort = Number(process.env.CDP_PORT ?? '9222');
 
-for (let i = 0; i < ports.length; i++) {
-  new RelaySession(ports[i]!, cdpPorts[i]!).start();
+  (async () => {
+    let targets;
+    try {
+      targets = await listTargets(cdpPort);
+    } catch (err) {
+      console.error('[main] Failed to reach Chrome:', (err as Error).message);
+      process.exit(1);
+    }
+
+    const pplxTargets = targets.filter(t => t.url.includes('perplexity.ai'));
+
+    if (pplxTargets.length < ports.length) {
+      console.error(`[main] Not enough perplexity.ai tabs open.`);
+      console.error(`[main]   Requested sessions : ${ports.length}`);
+      console.error(`[main]   Open pplx tabs found: ${pplxTargets.length}`);
+      console.error(`[main]   Open ${ports.length} perplexity.ai tabs in Chrome (port ${cdpPort}) and retry.`);
+      process.exit(1);
+    }
+
+    console.log(`[main] Multi-tab mode — ${ports.length} sessions on CDP port ${cdpPort}`);
+    for (let i = 0; i < ports.length; i++) {
+      const target = pplxTargets[i]!;
+      console.log(`[main]   :${ports[i]} → target ${target.id} (${target.url})`);
+      new RelaySession(ports[i]!, cdpPort, target.id).start();
+    }
+  })();
+
+} else {
+  // Single-session or legacy multi-process mode
+  const cdpPorts = parseList(process.env.CDP_PORTS ?? process.env.CDP_PORT, '9222');
+
+  if (ports.length !== cdpPorts.length) {
+    console.error('[main] PORTS and CDP_PORTS must have the same number of entries.');
+    console.error(`[main]   PORTS     = ${ports.join(', ')}`);
+    console.error(`[main]   CDP_PORTS = ${cdpPorts.join(', ')}`);
+    process.exit(1);
+  }
+
+  for (let i = 0; i < ports.length; i++) {
+    new RelaySession(ports[i]!, cdpPorts[i]!).start();
+  }
 }

--- a/packages/relay/src/relay-session.ts
+++ b/packages/relay/src/relay-session.ts
@@ -30,7 +30,18 @@ export class RelaySession {
   private reconnectDelayMs = RECONNECT_BASE_MS;
   private reconnectInFlight = false;
 
-  constructor(private port: number, private cdpPort: number) {
+  /**
+   * @param port       Relay HTTP/WS port.
+   * @param cdpPort    Chrome remote debugging port.
+   * @param targetId   Optional CDP target ID. When provided, this session is
+   *                   pinned to a specific Chrome tab. Omit for single-session
+   *                   use (picks the first perplexity.ai tab).
+   */
+  constructor(
+    private port: number,
+    private cdpPort: number,
+    private targetId?: string,
+  ) {
     this.cdp = new CDPSession(cdpPort);
     // stopScreenshots is handled inside reconnectCDP; no need to call it in the handler too
     this.cdp.setReconnectHandler(() => this.scheduleReconnect());
@@ -117,7 +128,7 @@ export class RelaySession {
     this.cdp.stopScreenshots();
     try {
       console.log(`[relay:${this.port}] reconnecting CDP...`);
-      await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+      await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg), this.targetId);
       this.cdp.startScreenshots(SCREENSHOT_FPS);
       console.log(`[relay:${this.port}] CDP reconnected`);
       await this.flushQueuedActions();
@@ -177,10 +188,12 @@ export class RelaySession {
     });
 
     app.get('/health', (_req, res) => res.json({
-      ok: true,
-      port: this.port,
-      cdpPort: this.cdpPort,
-      cdp: this.cdp.isConnected(),
+      ok:        true,
+      port:      this.port,
+      cdpPort:   this.cdpPort,
+      targetId:  this.cdp.targetId  || null,
+      targetUrl: this.cdp.targetUrl || null,
+      cdp:       this.cdp.isConnected(),
     }));
 
     wss.on('connection', (ws, req) => {
@@ -262,10 +275,14 @@ export class RelaySession {
       console.log(`  Actions      ws://localhost:${this.port}/actions`);
       console.log(`  Viewer       http://localhost:${this.port}/live`);
       console.log(`  Health       http://localhost:${this.port}/health\n`);
-      console.log(`  ⚠️  Chrome must be started with --remote-debugging-port=${this.cdpPort}\n`);
+      if (this.targetId) {
+        console.log(`  ⚠️  Pinned to CDP target ${this.targetId} on port ${this.cdpPort}\n`);
+      } else {
+        console.log(`  ⚠️  Chrome must be started with --remote-debugging-port=${this.cdpPort}\n`);
+      }
 
       try {
-        await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg));
+        await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg), this.targetId);
         this.reconnectDelayMs = RECONNECT_BASE_MS;
         this.cdp.startScreenshots(SCREENSHOT_FPS);
         console.log(`[relay:${this.port}] CDP ready — input + screenshots active\n`);

--- a/packages/relay/src/relay-session.ts
+++ b/packages/relay/src/relay-session.ts
@@ -264,8 +264,13 @@ export class RelaySession {
               return;
             }
 
-            const buffered = this.flushTypeBuffer();
-            if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+            // Don't flush the type buffer on click/mousemove — a click sets its own
+            // caret position. Flushing before the click would call el.focus() in the
+            // type handler, resetting the caret to end before the click lands.
+            if (parsed.type !== 'mousemove' && parsed.type !== 'click') {
+              const buffered = this.flushTypeBuffer();
+              if (buffered) this.enqueueOrRunAction({ type: 'type', value: buffered });
+            }
 
             if (parsed.type !== 'mousemove') {
               console.log(`[relay:${this.port}] action →`, JSON.stringify(parsed).slice(0, 120));

--- a/packages/relay/src/relay-session.ts
+++ b/packages/relay/src/relay-session.ts
@@ -23,6 +23,7 @@ type QueuedAction = {
 export class RelaySession {
   private cdp: CDPSession;
   private streamViewers = new Set<WebSocket>();
+  private pushers = new Set<WebSocket>();         // extension /stream/push senders
   private typeBuffer = '';
   private typeTimer: ReturnType<typeof setTimeout> | null = null;
   private queuedActions: QueuedAction[] = [];
@@ -30,20 +31,12 @@ export class RelaySession {
   private reconnectDelayMs = RECONNECT_BASE_MS;
   private reconnectInFlight = false;
 
-  /**
-   * @param port       Relay HTTP/WS port.
-   * @param cdpPort    Chrome remote debugging port.
-   * @param targetId   Optional CDP target ID. When provided, this session is
-   *                   pinned to a specific Chrome tab. Omit for single-session
-   *                   use (picks the first perplexity.ai tab).
-   */
   constructor(
     private port: number,
     private cdpPort: number,
     private targetId?: string,
   ) {
     this.cdp = new CDPSession(cdpPort);
-    // stopScreenshots is handled inside reconnectCDP; no need to call it in the handler too
     this.cdp.setReconnectHandler(() => this.scheduleReconnect());
   }
 
@@ -129,10 +122,12 @@ export class RelaySession {
     try {
       console.log(`[relay:${this.port}] reconnecting CDP...`);
       await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg), this.targetId);
-      this.cdp.startScreenshots(SCREENSHOT_FPS);
+      // Only start CDP screencast if no extension pushers are connected
+      if (this.pushers.size === 0) {
+        this.cdp.startScreenshots(SCREENSHOT_FPS);
+      }
       console.log(`[relay:${this.port}] CDP reconnected`);
       await this.flushQueuedActions();
-      // Reset backoff only after flush succeeds — so a bad-flush loop stays throttled
       this.reconnectDelayMs = RECONNECT_BASE_MS;
     } catch (err) {
       console.error(`[relay:${this.port}] reconnect failed:`, (err as Error).message);
@@ -200,9 +195,28 @@ export class RelaySession {
       const url = req.url ?? '';
 
       if (url === '/stream/push') {
-        console.log(`[relay:${this.port}] ▲ streamer connected (CDP mode ignores this)`);
-        ws.on('message', () => {});
-        ws.on('close', () => console.log(`[relay:${this.port}] ▼ streamer disconnected`));
+        // Extension frame pusher — preferred over CDP screencast
+        this.pushers.add(ws);
+        console.log(`[relay:${this.port}] ▲ extension pusher connected (total: ${this.pushers.size}) — pausing CDP screencast`);
+        // Stop CDP screencast while extension is pushing frames (avoids dual render)
+        if (this.cdp.isConnected()) this.cdp.stopScreenshots();
+
+        ws.on('message', (data) => {
+          // Forward raw JPEG binary from extension to all stream viewers
+          const buf = data instanceof Buffer ? data : Buffer.from(data as ArrayBuffer);
+          for (const v of this.streamViewers) {
+            if (v.readyState === WebSocket.OPEN) v.send(buf, { binary: true });
+          }
+        });
+
+        ws.on('close', () => {
+          this.pushers.delete(ws);
+          console.log(`[relay:${this.port}] ▼ extension pusher disconnected — resuming CDP screencast`);
+          // Resume CDP screencast when extension disconnects
+          if (this.cdp.isConnected() && this.pushers.size === 0) {
+            this.cdp.startScreenshots(SCREENSHOT_FPS);
+          }
+        });
 
       } else if (url === '/stream') {
         this.streamViewers.add(ws);
@@ -221,7 +235,7 @@ export class RelaySession {
 
           if (parsed?.register === 'extension') {
             isReceiver = true;
-            console.log(`[relay:${this.port}] ▲ action-receiver (ext) connected — CDP mode: extension ignored for input`);
+            console.log(`[relay:${this.port}] ▲ action-receiver (ext) connected`);
             return;
           }
 
@@ -284,8 +298,11 @@ export class RelaySession {
       try {
         await this.cdp.connect((jpeg) => this.broadcastFrame(jpeg), this.targetId);
         this.reconnectDelayMs = RECONNECT_BASE_MS;
-        this.cdp.startScreenshots(SCREENSHOT_FPS);
-        console.log(`[relay:${this.port}] CDP ready — input + screenshots active\n`);
+        // Start CDP screencast only if no extension pusher is already connected
+        if (this.pushers.size === 0) {
+          this.cdp.startScreenshots(SCREENSHOT_FPS);
+        }
+        console.log(`[relay:${this.port}] CDP ready — input active, screencast ${ this.pushers.size > 0 ? 'deferred (extension pushing)' : 'active' }\n`);
       } catch (err) {
         console.error(`[relay:${this.port}] CDP connect failed:`, (err as Error).message);
         this.scheduleReconnect();

--- a/packages/viewer/public/live.html
+++ b/packages/viewer/public/live.html
@@ -43,7 +43,9 @@
   </div>
 
   <script>
-    const PORT   = 7001;
+    // Derive relay port from the URL this page was served from so that
+    // localhost:7002/live connects to :7002, not the hardcoded :7001.
+    const PORT   = parseInt(window.location.port, 10) || 7001;
     const canvas = document.getElementById('screen');
     const ctx    = canvas.getContext('2d');
     const status = document.getElementById('status');


### PR DESCRIPTION
Closes #93

## What

Allows multiple relay sessions to share a **single Chrome process** by pinning each `CDPSession` to a specific tab (CDP target ID), rather than requiring one Chrome per relay port.

## Changes

### `cdp.ts`
- `listTargets(cdpPort)` — fetches `/json` and returns all `page` targets
- `connect(callback, targetId?)` — optional `targetId` pins the session to a specific tab and remembers it across reconnects via `pinnedTargetId`
- `readonly targetId` / `readonly targetUrl` — populated after `connect()` resolves

### `relay-session.ts`
- `constructor(port, cdpPort, targetId?)` — passes `targetId` to `cdp.connect()`
- `/health` response now includes `targetId` and `targetUrl`
- Startup banner shows which target the session is pinned to

### `main.ts`
- **Multi-tab mode** (new): `PORTS=7001,7002 CDP_PORT=9222`  
  Enumerates `perplexity.ai` tabs at startup, fails fast if not enough are open, zips ports ↔ targets
- **Legacy multi-process mode** unchanged: `PORTS=7001,7002 CDP_PORTS=9222,9223`
- **Single session** unchanged: `PORT=7001 CDP_PORT=9222`

## Usage

```bash
# Open 2+ perplexity.ai tabs in Chrome (--remote-debugging-port=9222)
PORTS=7001,7002 CDP_PORT=9222 node dist/main.js
```

## Backward compatibility

All existing env-var combinations continue to work exactly as before. No breaking changes.