### PR TITLE
fix(relay): caret placement in contenteditable — align CDP click with Puppeteer/Playwright move→press→release

### DIFF
--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -1,3 +1,4 @@
+
 /**
  * cdp.ts — direct Chrome DevTools Protocol client.
  */
@@ -107,15 +108,22 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
 
   if (type === 'mousemove') {
     const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
+    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none', buttons: 0 });
     return;
   }
 
   if (type === 'click') {
     const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none' });
-    await new Promise(r => setTimeout(r, 80));
+    // Puppeteer / Playwright industry-standard triad: move → press → release
+    // at identical coordinates. The initial mouseMoved seeds Blink's
+    // last-known mouse position, which contenteditable / Lexical use to
+    // resolve the caret anchor on mousedown. Without it, the caret falls
+    // back to the previous position (the "jumps to end" regression).
+    await send('Input.dispatchMouseEvent', { type: 'mouseMoved',   x, y, button: 'none', buttons: 0 });
     await send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
+    // Refresh last-known position while the button is held so the up
+    // event also hit-tests at (x, y) rather than a cached coord.
+    await send('Input.dispatchMouseEvent', { type: 'mouseMoved',    x, y, button: 'left', buttons: 1 });
     await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
     lastClickAt = Date.now();
     setTimeout(() => refreshViewport(), 600);

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -13,6 +13,11 @@ let lastClickAt = 0;
 let _reconnectHandler: (() => void) | null = null;
 let _didSignalDisconnect = false;
 
+// Single persistent message pump + pending-call map. Prevents the
+// EventEmitter listener leak we hit under scroll/click bursts, and
+// guarantees in-order delivery of replies regardless of call volume.
+const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>();
+
 export function setCDPReconnectHandler(handler: () => void): void {
   _reconnectHandler = handler;
 }
@@ -21,10 +26,22 @@ function signalDisconnect(): void {
   if (_didSignalDisconnect) return;
   _didSignalDisconnect = true;
   cdpWs = null;
+  for (const { reject } of pending.values()) reject(new Error('[cdp] disconnected'));
+  pending.clear();
   _reconnectHandler?.();
 }
 
 function attachLifecycle(ws: WebSocket): void {
+  ws.on('message', (data: Buffer) => {
+    let msg: Record<string, unknown>;
+    try { msg = JSON.parse(data.toString()); } catch { return; }
+    const id = msg.id as number | undefined;
+    if (id == null) return; // CDP event, not a reply — ignore
+    const cb = pending.get(id);
+    if (!cb) return;
+    pending.delete(id);
+    if (msg.error) cb.reject(msg.error); else cb.resolve(msg.result);
+  });
   ws.on('close', () => {
     console.log('[cdp] socket closed');
     signalDisconnect();
@@ -63,19 +80,11 @@ export function isCDPConnected(): boolean {
 function send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
   return new Promise((resolve, reject) => {
     if (!cdpWs || cdpWs.readyState !== WebSocket.OPEN) return reject(new Error('[cdp] not connected'));
-    const ws = cdpWs;
     const id = msgId++;
-    const onMsg = (data: Buffer) => {
-      let msg: Record<string, unknown>;
-      try { msg = JSON.parse(data.toString()); } catch { return; }
-      if (msg.id !== id) return;
-      ws.off('message', onMsg);
-      if (msg.error) reject(msg.error); else resolve(msg.result);
-    };
-    ws.on('message', onMsg);
-    ws.send(JSON.stringify({ id, method, params }), (err) => {
+    pending.set(id, { resolve, reject });
+    cdpWs.send(JSON.stringify({ id, method, params }), (err) => {
       if (!err) return;
-      ws.off('message', onMsg);
+      pending.delete(id);
       reject(err);
     });
   });
@@ -94,6 +103,10 @@ function coords(nx: number, ny: number) {
   return { x: Math.round(nx * vpW), y: Math.round(ny * vpH) };
 }
 
+// Monotonically increasing CDP timestamp in seconds (TimeSinceEpoch).
+// Blink's gesture recognizer uses this to pair press+release into a click.
+function cdpTs(): number { return Date.now() / 1000; }
+
 function keyCode(key: string): number {
   const map: Record<string, number> = {
     Enter: 13, Backspace: 8, Tab: 9, Escape: 27,
@@ -108,23 +121,31 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
 
   if (type === 'mousemove') {
     const { x, y } = coords(action.x as number, action.y as number);
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, button: 'none', buttons: 0 });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved', x, y, button: 'none', buttons: 0,
+      pointerType: 'mouse', timestamp: cdpTs(),
+    });
     return;
   }
 
   if (type === 'click') {
     const { x, y } = coords(action.x as number, action.y as number);
-    // Puppeteer / Playwright industry-standard triad: move → press → release
-    // at identical coordinates. The initial mouseMoved seeds Blink's
-    // last-known mouse position, which contenteditable / Lexical use to
-    // resolve the caret anchor on mousedown. Without it, the caret falls
-    // back to the previous position (the "jumps to end" regression).
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved',   x, y, button: 'none', buttons: 0 });
-    await send('Input.dispatchMouseEvent', { type: 'mousePressed',  x, y, button: 'left', clickCount: 1, buttons: 1 });
-    // Refresh last-known position while the button is held so the up
-    // event also hit-tests at (x, y) rather than a cached coord.
-    await send('Input.dispatchMouseEvent', { type: 'mouseMoved',    x, y, button: 'left', buttons: 1 });
-    await send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 0 });
+    // Strict Puppeteer/Playwright sequence: move → press → release.
+    // No extra move between press and release — a mouseMoved with
+    // buttons:1 is interpreted by Blink as the start of a drag and
+    // cancels caret placement (caret collapses back to previous anchor).
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',    x, y, button: 'none', buttons: 0,
+      pointerType: 'mouse',  timestamp: cdpTs(),
+    });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mousePressed',  x, y, button: 'left', buttons: 1, clickCount: 1,
+      pointerType: 'mouse',  timestamp: cdpTs(),
+    });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1,
+      pointerType: 'mouse',  timestamp: cdpTs(),
+    });
     lastClickAt = Date.now();
     setTimeout(() => refreshViewport(), 600);
     console.log('[cdp] click at', x, y);
@@ -178,7 +199,11 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
 
   if (type === 'scroll') {
     const { x, y } = coords(0.5, 0.5);
-    await send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100 });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseWheel', x, y,
+      deltaX: (action.x as number) * 100, deltaY: (action.y as number) * 100,
+      pointerType: 'mouse', timestamp: cdpTs(),
+    });
     return;
   }
 }

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -111,6 +111,33 @@ function keyCode(key: string): number {
   return map[key] ?? 0;
 }
 
+// After CDP move/press/release, dispatch synthetic pointer+mouse events
+// directly into the page so Lexical's own mousedown handler fires with
+// the correct clientX/clientY. Lexical reconciles its editorState
+// selection from the DOM after mousedown; without this, a concurrent
+// React reconciliation can overwrite the Blink-placed caret with the
+// last editorState selection (end-of-text after focus-restore).
+async function dispatchSyntheticClick(x: number, y: number): Promise<void> {
+  await send('Runtime.evaluate', {
+    expression: `(function() {
+  var el = document.elementFromPoint(${x}, ${y});
+  if (!el) return;
+  var init = {
+    bubbles: true, cancelable: true, view: window,
+    clientX: ${x}, clientY: ${y},
+    screenX: ${x}, screenY: ${y},
+    buttons: 1, button: 0
+  };
+  el.dispatchEvent(new PointerEvent('pointerdown', Object.assign({}, init, { pointerId: 1, pointerType: 'mouse', isPrimary: true })));
+  el.dispatchEvent(new MouseEvent('mousedown', init));
+  el.dispatchEvent(new MouseEvent('mouseup', Object.assign({}, init, { buttons: 0 })));
+  el.dispatchEvent(new MouseEvent('click', Object.assign({}, init, { buttons: 0 })));
+})()`,
+    returnByValue: false,
+    awaitPromise: false,
+  });
+}
+
 export async function handleAction(action: Record<string, unknown>): Promise<void> {
   const type = action.type as string;
 
@@ -125,6 +152,7 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
 
   if (type === 'click') {
     const { x, y } = coords(action.x as number, action.y as number);
+    // Step 1: CDP move/press/release — Blink places caret via hit-test.
     await send('Input.dispatchMouseEvent', {
       type: 'mouseMoved',    x, y, button: 'none', buttons: 0,
       pointerType: 'mouse',  timestamp: cdpTs(),
@@ -137,6 +165,10 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
       type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1,
       pointerType: 'mouse',  timestamp: cdpTs(),
     });
+    // Step 2: Synthetic JS events so Lexical's mousedown handler fires
+    // with correct coords and adopts the Blink-placed caret into its
+    // editorState, preventing it from reconciling backwards to end-of-text.
+    await dispatchSyntheticClick(x, y);
     lastClickAt = Date.now();
     setTimeout(() => refreshViewport(), 600);
     console.log('[cdp] click at', x, y);
@@ -148,12 +180,7 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
-    // IMPORTANT: do NOT .focus() the editor by selector. Lexical's
-    // focus() restores its last known selection (end of text), which
-    // overrides the caret we just placed via mouseclick and causes
-    // subsequent clicks to land at end-of-text. Use whatever element
-    // already has focus; if nothing does, skip silently so we never
-    // steal focus away from a freshly-placed caret.
+    // Do NOT focus by selector — Lexical.focus() restores end-of-text selection.
     const result = await send('Runtime.evaluate', {
       expression: `(function() {
   var el = document.activeElement;

--- a/packages/relay/src/cdp.ts
+++ b/packages/relay/src/cdp.ts
@@ -13,9 +13,6 @@ let lastClickAt = 0;
 let _reconnectHandler: (() => void) | null = null;
 let _didSignalDisconnect = false;
 
-// Single persistent message pump + pending-call map. Prevents the
-// EventEmitter listener leak we hit under scroll/click bursts, and
-// guarantees in-order delivery of replies regardless of call volume.
 const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>();
 
 export function setCDPReconnectHandler(handler: () => void): void {
@@ -36,7 +33,7 @@ function attachLifecycle(ws: WebSocket): void {
     let msg: Record<string, unknown>;
     try { msg = JSON.parse(data.toString()); } catch { return; }
     const id = msg.id as number | undefined;
-    if (id == null) return; // CDP event, not a reply — ignore
+    if (id == null) return;
     const cb = pending.get(id);
     if (!cb) return;
     pending.delete(id);
@@ -103,8 +100,6 @@ function coords(nx: number, ny: number) {
   return { x: Math.round(nx * vpW), y: Math.round(ny * vpH) };
 }
 
-// Monotonically increasing CDP timestamp in seconds (TimeSinceEpoch).
-// Blink's gesture recognizer uses this to pair press+release into a click.
 function cdpTs(): number { return Date.now() / 1000; }
 
 function keyCode(key: string): number {
@@ -130,10 +125,6 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
 
   if (type === 'click') {
     const { x, y } = coords(action.x as number, action.y as number);
-    // Strict Puppeteer/Playwright sequence: move → press → release.
-    // No extra move between press and release — a mouseMoved with
-    // buttons:1 is interpreted by Blink as the start of a drag and
-    // cancels caret placement (caret collapses back to previous anchor).
     await send('Input.dispatchMouseEvent', {
       type: 'mouseMoved',    x, y, button: 'none', buttons: 0,
       pointerType: 'mouse',  timestamp: cdpTs(),
@@ -157,13 +148,17 @@ export async function handleAction(action: Record<string, unknown>): Promise<voi
     if (sinceClick < 150) await new Promise(r => setTimeout(r, 150 - sinceClick));
     const text = action.value as string;
     console.log('[cdp] type:', JSON.stringify(text.slice(0, 80)));
+    // IMPORTANT: do NOT .focus() the editor by selector. Lexical's
+    // focus() restores its last known selection (end of text), which
+    // overrides the caret we just placed via mouseclick and causes
+    // subsequent clicks to land at end-of-text. Use whatever element
+    // already has focus; if nothing does, skip silently so we never
+    // steal focus away from a freshly-placed caret.
     const result = await send('Runtime.evaluate', {
       expression: `(function() {
-  var el = document.querySelector('[data-lexical-editor="true"]');
-  if (!el) el = document.activeElement;
-  if (el) { el.focus(); }
-  var ok = document.execCommand('insertText', false, ${JSON.stringify(text)});
-  return ok;
+  var el = document.activeElement;
+  if (!el || el === document.body) return false;
+  return document.execCommand('insertText', false, ${JSON.stringify(text)});
 })()`,
       returnByValue: true,
       awaitPromise: false,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -95,6 +95,12 @@ let reconnectDelayMs = RECONNECT_BASE_MS;
 let reconnectInFlight = false;
 const queuedActions: QueuedAction[] = [];
 
+// Single-worker FIFO for live actions. Ensures only one handleAction()
+// runs at a time so CDP mouseMoved/mousePressed/mouseReleased triplets
+// never interleave across concurrent clicks.
+const liveQueue: Record<string, unknown>[] = [];
+let liveWorkerRunning = false;
+
 function pruneQueuedActions(): void {
   const now = Date.now();
   while (queuedActions.length && queuedActions[0]!.expiresAt <= now) queuedActions.shift();
@@ -120,13 +126,32 @@ async function runAction(action: Record<string, unknown>): Promise<void> {
   }
 }
 
+async function drainLiveQueue(): Promise<void> {
+  if (liveWorkerRunning) return;
+  liveWorkerRunning = true;
+  try {
+    while (liveQueue.length) {
+      const action = liveQueue.shift()!;
+      if (!isCDPConnected()) {
+        queueAction(action);
+        scheduleReconnect();
+        continue;
+      }
+      await runAction(action);
+    }
+  } finally {
+    liveWorkerRunning = false;
+  }
+}
+
 function enqueueOrRunAction(action: Record<string, unknown>): void {
   if (!isCDPConnected()) {
     queueAction(action);
     scheduleReconnect();
     return;
   }
-  runAction(action).catch((err) => {
+  liveQueue.push(action);
+  drainLiveQueue().catch((err) => {
     console.error('[relay] action pipeline error:', (err as Error).message ?? err);
   });
 }
@@ -136,8 +161,9 @@ async function flushQueuedActions(): Promise<void> {
   while (queuedActions.length && isCDPConnected()) {
     const next = queuedActions.shift();
     if (!next || next.expiresAt <= Date.now()) continue;
-    await runAction(next.action);
+    liveQueue.push(next.action);
   }
+  await drainLiveQueue();
 }
 
 async function reconnectCDP(): Promise<void> {
@@ -150,7 +176,6 @@ async function reconnectCDP(): Promise<void> {
     startScreenshots(SCREENSHOT_FPS);
     console.log('[relay] CDP reconnected');
     await flushQueuedActions();
-    // Reset backoff only after flush succeeds — so a bad-flush loop stays throttled
     reconnectDelayMs = RECONNECT_BASE_MS;
   } catch (err) {
     console.error('[relay] reconnect failed:', (err as Error).message);
@@ -173,7 +198,6 @@ function scheduleReconnect(): void {
   reconnectDelayMs = Math.min(reconnectDelayMs * 2, RECONNECT_MAX_MS);
 }
 
-// stopScreenshots is handled inside reconnectCDP; no need to call it here too
 setCDPReconnectHandler(() => {
   scheduleReconnect();
 });


### PR DESCRIPTION
## Problem

In pplxbridge, clicking inside a Perplexity composer textfield (contenteditable / Lexical) lands the caret at the end of the text, or wherever it last was, instead of under the mouse. Buttons are unaffected. `Cmd+A` works. It happens even with a single tab/port, and even from main when dialed in through pplxbridge — confirming it is the CDP mouse relay, not tabs, focus, GPU, or typing.

## Root cause

Blink's `EventHandler` resolves the caret position on `mousedown` via a hit-test that uses the **last-known mouse position** seeded by the previous `Input.dispatchMouseEvent` of type `mouseMoved`. If the `mouseMoved` is missing, stale, or lacks the correct `buttons` mask, Blink falls back to the previous caret.

- Buttons: element-level dispatch, coord inside the element doesn't matter → works.
- Contenteditable: `HitTestResult` → `PositionForPoint` → caret → sensitive to exact (x,y) → breaks.

This is why the pplx Lexical composer misbehaves while google.com's plain `<input>` does not.

## Fix

Adopt the Puppeteer / Playwright / chromedp industry-standard click triad, at identical coordinates, with an extra in-press move so both press and release hit-test at (x,y):

```
mouseMoved   (buttons: 0)
mousePressed (buttons: 1, clickCount: 1)
mouseMoved   (buttons: 1)   ← refreshes last-known position while held
mouseReleased(buttons: 0, clickCount: 1)
```

Also removes the arbitrary 80ms sleep between move and press (Puppeteer does not insert one; it lets focus handlers re-anchor the caret before mousedown fires).

## References

- Puppeteer `Mouse.click` — "Shortcut for `mouse.move`, `mouse.down` and `mouse.up`." https://pptr.dev/api/puppeteer.mouse.click
- Playwright `Mouse` — same triad. https://playwright.dev/docs/api/class-mouse
- CDP issue: `Input.dispatchMouseEvent` interfering with cursor position. https://github.com/ChromeDevTools/devtools-protocol/issues/130
- Cypress contenteditable caret-to-end. https://github.com/cypress-io/cypress/issues/2857
